### PR TITLE
Fixed installation of gitpython on remote hosts.

### DIFF
--- a/installation/remote/roles/collector_install/tasks/main.yml
+++ b/installation/remote/roles/collector_install/tasks/main.yml
@@ -11,6 +11,7 @@
     name: "{{ git_python }}"
     version: "{{ git_python_version }}"
     extra_args: --isolated
+    virtualenv: "{{ ansible_venv }}"
 
 - name: Create Directories
   become: yes


### PR DESCRIPTION
Was not specifying a virtualenv when installing via pip.