### PR TITLE
Changed long running tasks to async mode.

### DIFF
--- a/syndication/roles/collect/defaults/main.yml
+++ b/syndication/roles/collect/defaults/main.yml
@@ -9,3 +9,6 @@ cloud_snitch_conf_file: "{{ cloud_snitch_conf_dir }}/cloud_snitch.yml"
 cloud_snitch_inventory_locations:
   # - /opt/openstack-ansible/playbooks/inventory/
   - /opt/rpc-openstack/openstack-ansible/playbooks/inventory/
+
+cloud_snitch_collection_timeout: 1800
+cloud_snitch_collection_poll: 30

--- a/syndication/roles/collect/tasks/main.yml
+++ b/syndication/roles/collect/tasks/main.yml
@@ -15,6 +15,8 @@
   tags:
     - collect
   when: osa_details.major_release and osa_details.major_release >= 14
+  async: "{{ cloud_snitch_collection_timeout }}"
+  poll: "{{ cloud_snitch_collection_poll }}"
 
 - name: Debug inventories
   debug:
@@ -35,6 +37,8 @@
   tags:
     - collect
   when: osa_details.major_release and osa_details.major_release < 14
+  async: "{{ cloud_snitch_collection_timeout }}"
+  poll: "{{ cloud_snitch_collection_poll }}"
 
 - name: Find all cloud_snitch data sets
   find:

--- a/syndication/roles/sync/defaults/main.yml
+++ b/syndication/roles/sync/defaults/main.yml
@@ -2,3 +2,5 @@ cloud_snitch_conf_dir: /etc/cloud_snitch
 cloud_snitch_data_dir: "{{ cloud_snitch_conf_dir }}/data"
 cloud_snitch_sync_concurrency: 4
 cloud_snitch_sync_venv: '/opt/venvs/cloudsnitch'
+cloud_snitch_sync_timeout: 3600
+cloud_snitch_sync_poll: 30

--- a/syndication/roles/sync/tasks/main.yml
+++ b/syndication/roles/sync/tasks/main.yml
@@ -28,6 +28,8 @@
   command: "{{ cloud_snitch_sync_venv }}/bin/cloud-snitch-sync --concurrency {{ cloud_snitch_sync_concurrency }}"
   tags:
     - sync
+  async: "{{ cloud_snitch_sync_timeout }}"
+  poll: "{{ cloud_snitch_sync_poll }}"
 
 - name: Run cloud-snitch-clean
   command: "{{ cloud_snitch_sync_venv }}/bin/cloud-snitch-clean"


### PR DESCRIPTION
The collect and sync tasks are now in ansible async mode.
This will help alleviate unreachable error statuses that are the
result of ssh timeouts during long running tasks.