### PR TITLE
Fixed issue ET-34.

### DIFF
--- a/cloud_snitch/runs.py
+++ b/cloud_snitch/runs.py
@@ -161,9 +161,16 @@ def find_runs():
                 except RunInvalidError:
                     continue
 
-    # Sort runs be completed timestamp
-    runs = sorted(runs, key=lambda r: r.completed)
-    return runs
+    # Exclude runs that are incomplete
+    filtered = []
+    for run in runs:
+        if run.completed is None:
+            logger.warn('Found incomplete run at {}'.format(run.path))
+            continue
+        filtered.append(run)
+
+    # Sort runs by completed timestamp
+    return sorted(filtered, key=lambda r: r.completed)
 
 
 def set_current(run):


### PR DESCRIPTION
Bug was with run finding and sorting. The sorting would try to
compare the completed attribute of a run which may not exist in
the event of an incomplete run. Comparing a datetime and a None
would result in an exception. This occurs before any processing
or digestion of a run and is not caught by the exception wrapper
around run ingestion.