### PR TITLE
Adds the ability to move beyond the five default forks.

### DIFF
--- a/syndication/roles/collect/defaults/main.yml
+++ b/syndication/roles/collect/defaults/main.yml
@@ -12,3 +12,6 @@ cloud_snitch_inventory_locations:
 
 cloud_snitch_collection_timeout: 1800
 cloud_snitch_collection_poll: 30
+
+cloud_snitch_default_forks: "{{ [ansible_processor_vcpus - 2, 8]| max }}"
+cloud_snitch_forks: "{{ cloud_snitch_default_forks }}"

--- a/syndication/roles/collect/tasks/main.yml
+++ b/syndication/roles/collect/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Run snitch collector - Newton +
   become: yes
-  command: "openstack-ansible snitch.yml"
+  command: "openstack-ansible snitch.yml --forks {{ cloud_snitch_forks }}"
   environment:
     CLOUD_SNITCH_ENABLED: true
     CLOUD_SNITCH_CONF_FILE: "{{ cloud_snitch_conf_file }}"
@@ -24,7 +24,7 @@
 
 - name: Run snitch collector - Mitaka -
   become: yes
-  command: "openstack-ansible snitch.yml"
+  command: "openstack-ansible snitch.yml --forks {{ cloud_snitch_forks }}"
   environment:
     CLOUD_SNITCH_ENABLED: true
     CLOUD_SNITCH_CONF_FILE: "{{ cloud_snitch_conf_file }}"


### PR DESCRIPTION
The number of forks used when running openstack-ansible snitch.yml
can greatly affect the run time. For large environments, 5 forks
may not be enough to finish within a reasonable amount of time.

This change allows one to specify the number of forks. If this is
not specified, the number of forks will default to:
    max(number of threads - 2, 8)