### PR TITLE
Fixed csv column ordering bug.

### DIFF
--- a/web/reports/tests/test_views.py
+++ b/web/reports/tests/test_views.py
@@ -4,6 +4,8 @@ from collections import OrderedDict
 from django.test import tag
 from rest_framework import status
 
+from reports.views import ReportViewSet
+
 from .base import APITestCase
 
 
@@ -20,6 +22,10 @@ class FakeReport:
         d['keya'] = 'value1'
         d['keyb'] = 'value2'
         return [d]
+
+    def columns(self):
+        """Return dummy data columns."""
+        return ['keya', 'keyb']
 
 
 class TestReportsViewSet(APITestCase):
@@ -97,3 +103,16 @@ class TestReportsViewSet(APITestCase):
         result = resp.json()
         self.assertEquals(result[0]['keya'], 'value1')
         self.assertEquals(result[0]['keyb'], 'value2')
+
+    def test_get_renderer_context(self):
+        """Test that get_renderer_context can detect columns."""
+        v = ReportViewSet()
+
+        v.columns = None
+        ctx = v.get_renderer_context()
+        self.assertTrue(ctx.get('header') is None)
+
+        v.columns = ['a', 'b', 'c']
+        ctx = v.get_renderer_context()
+        for i, name in enumerate(v.columns):
+            self.assertEquals(name, ctx['header'][i])

--- a/web/reports/views.py
+++ b/web/reports/views.py
@@ -48,6 +48,17 @@ class ReportViewSet(viewsets.ViewSet):
         # This will raise a validationerror if report parameters are invalid
         report = report_class(request.data)
 
+        # Save columns for renderer context
+        self.columns = report.columns()
+
         # Run report and serialize the result
         s = ReportDataSerializer(report.run())
         return Response(s.data)
+
+    def get_renderer_context(self):
+        """Add column ordering to renderer context for csvs."""
+        context = super().get_renderer_context()
+        columns = getattr(self, 'columns', None)
+        if columns is not None:
+            context['header'] = columns
+        return context


### PR DESCRIPTION
Added 'header' attribute to renderer context. Without setting
this attribute, the csv renderer will determine all possible
column names and then sort them for the default order.