### PR TITLE
Added console script to terminate an environment in cloud snitch.

### DIFF
--- a/cloud_snitch/cli_common.py
+++ b/cloud_snitch/cli_common.py
@@ -1,0 +1,68 @@
+"""
+Collection of common code shared between console scripts.
+"""
+import argparse
+from cloud_snitch.models import EnvironmentEntity
+from cloud_snitch.exc import EnvironmentNotFoundError
+
+from cloud_snitch.meta import version
+
+
+def base_parser(**kwargs):
+    """Creates a base argument parser that includes version as an option.
+
+    Console scripts should add to this parser to share version functionality.
+
+    :returns: Instance of an argument parser.
+    :rtype: argparse.ArgumentParser
+    """
+    parser = argparse.ArgumentParser(**kwargs)
+    parser.add_argument(
+        '-v', '--version',
+        help='Display version and exit.',
+        action='version',
+        version='%(prog)s {}'.format(version)
+    )
+    return parser
+
+
+def confirm_env_action(account_number, name, msg, skip=False):
+    """Confirm an action on an environment.
+
+    :param account number: Account number of environment
+    :type account number: str
+    :param name: Name of the environment
+    :type name: str
+    :param msg: Message to display when asking for input.
+    :type msg: str
+    :param skip: Whether or not to skip bypass
+    :type skip: bool
+    :returns: Whether or not remove is confirmed.
+    :rtype: bool
+    """
+    confirmed = skip
+    if not confirmed:
+        msg = '{} (y/n) --> '.format(msg)
+        resp = ''
+        while (resp != 'y' and resp != 'n'):
+            resp = input(msg).lower()
+        confirmed = (resp == 'y')
+    return confirmed
+
+
+def find_environment(session, account_number, name):
+    """Find an environment by account number and name.
+
+    :param session: neo4j driver session
+    :type session: neo4j.v1.session.BoltSession
+    :param account number: Account number of environment
+    :type account number: str
+    :param name: Name of the environment
+    :type name: str
+    :returns: Environment entity
+    :rtype: EnvironmentEntity
+    """
+    env = EnvironmentEntity.find(session, '{}-{}'.format(account_number, name))
+    if env is None:
+        raise EnvironmentNotFoundError(account_number, name)
+    return env

--- a/cloud_snitch/terminate.py
+++ b/cloud_snitch/terminate.py
@@ -1,0 +1,159 @@
+"""Quick module for terminating relationships for an environment."""
+import logging
+import pprint
+import time
+
+from cloud_snitch import settings
+from cloud_snitch import utils
+from cloud_snitch.cli_common import base_parser
+from cloud_snitch.cli_common import confirm_env_action
+from cloud_snitch.cli_common import find_environment
+from cloud_snitch.lock import lock_environment
+from cloud_snitch.models import EnvironmentEntity
+from cloud_snitch.models import registry
+from cloud_snitch.exc import EnvironmentNotFoundError
+from neo4j.v1 import GraphDatabase
+
+logger = logging.getLogger(__name__)
+
+parser = base_parser(
+    description=(
+        "Terminate an environment. Mark ending time on all relationships "
+        "stemming from the environment."
+    )
+)
+
+parser.add_argument(
+    'account_number',
+    type=str,
+    help='Account number of customer environment to terminate.'
+)
+
+parser.add_argument(
+    'name',
+    type=str,
+    help='Name of customer environment to terminate.'
+)
+
+parser.add_argument(
+    '-s', '--skip',
+    action='store_true',
+    help='Skip interactive confirmation.'
+)
+
+parser.add_argument(
+    '--time',
+    type=int,
+    help="Optional timestamp in ms. Defaults to utc now.",
+    default=utils.milliseconds_now()
+)
+
+parser.add_argument(
+    '--limit',
+    type=int,
+    help="Optional number of paths to consider at a time. Defaults to 2000.",
+    default=2000
+)
+
+
+def set_to_until_zero(session, env, time, limit=2000):
+    """Set current relationships' to attributes to time.
+
+    Runs in a loop until there are no more current relationships.
+
+    :param session: Neo4j driver session.
+    :type session: neo4j.v1.session.BoltSession
+    :param env: Instance of environment entity.
+    :type env: EnvironmentEntity
+    :param time: Timestamp in ms.
+    :type time: int
+    :param limit: Number of items to delete at a time.
+        When deleting nodes with large numbers of relationships,
+        consider making this smaller.
+    :type limit: int
+    :return: The number of changed relationships.
+    :rtype: int
+    """
+    params = {
+        'time': time,
+        'limit': limit,
+        'EOT': utils.EOT,
+        'account_number_name': env.account_number_name
+    }
+    total_changed = 0
+    changed = 1
+
+    # Alter query for deleting in chunks
+    cipher = (
+        "MATCH p = "
+        "(e:Environment {account_number_name: $account_number_name})-[*]->(o)\n"  # noqa E501
+        "WHERE ANY(rel in relationships(p) where rel.to = $EOT)\n"
+        "WITH filter(rel in relationships(p) where rel.to = $EOT) "
+        "as rels LIMIT $limit\n"
+        "UNWIND rels as r\n"
+        "SET r.to = $time\n"
+        "RETURN count(*) as changed\n"
+    )
+    # Keep going until 0.
+    while changed > 0:
+        with session.begin_transaction() as tx:
+            resp = tx.run(cipher, **params)
+            changed = resp.single()['changed']
+            total_changed += changed
+    return total_changed
+
+
+def terminate(account_number, name, new_time, limit, skip=False):
+    """Remove all data associated with an environment."""
+    driver = GraphDatabase.driver(
+        settings.NEO4J_URI,
+        auth=(settings.NEO4J_USERNAME, settings.NEO4J_PASSWORD)
+    )
+    with driver.session() as session:
+        # Attempt to locate environment by account number and name
+        env = find_environment(session, account_number, name)
+
+        # If found, confirm termination
+        msg = (
+            'Confirming termination of environment with account '
+            'number \'{}\' and name \'{}\''
+            .format(account_number, name)
+        )
+        confirmed = confirm_env_action(account_number, name, msg, skip=skip)
+        if not confirmed:
+            logger.info("Termination unconfirmed...cancelling.")
+            exit(0)
+
+        # Acquire lock and and terminate
+        start = time.time()
+        with lock_environment(driver, env.account_number, env.name):
+
+            logger.debug("Acquired the lock.!!!")
+
+            # Match relation ships with to property set to java end of time.
+            # And bulk update until 0 matches.
+            changed = set_to_until_zero(session, env, new_time, limit=limit)
+
+            logger.info(
+                "Terminated {} relationships at {}.".format(changed, new_time)
+            )
+
+        logger.info(
+            "Completed termination in {:.3f}s".format(time.time() - start)
+        )
+
+
+def main():
+    """Entry point for the console script."""
+    args = parser.parse_args()
+    terminate(
+        args.account_number,
+        args.name,
+        args.time,
+        args.limit,
+        skip=args.skip
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/cloud_snitch/tests/test_cli_common.py
+++ b/cloud_snitch/tests/test_cli_common.py
@@ -1,0 +1,93 @@
+import mock
+import sys
+import unittest
+
+from io import StringIO
+
+from cloud_snitch.cli_common import base_parser
+from cloud_snitch.cli_common import confirm_env_action
+from cloud_snitch.cli_common import find_environment
+from cloud_snitch.exc import EnvironmentNotFoundError
+
+
+class TestBaseParser(unittest.TestCase):
+    """Test the base parser.  The base parser adds a common version action."""
+
+    def setUp(self):
+        self.old_stream = sys.stdout
+        self.stream = StringIO()
+        sys.stdout = self.stream
+
+    def tearDown(self):
+        sys.stdout = self.old_stream
+        self.stream.close()
+
+    def test_base_parser(self):
+        """Test behaviour of default options."""
+        parser = base_parser(description='test_description')
+        self.assertEqual(parser.description, 'test_description')
+        with self.assertRaises(SystemExit):
+            parser.parse_args(['-v'])
+
+
+class TestFindEnvironment(unittest.TestCase):
+
+    @mock.patch(
+        'cloud_snitch.remove.EnvironmentEntity.find',
+        return_value=None
+    )
+    def test_find_no_match(self, m_find):
+        """Test that error is raised on no match."""
+        with self.assertRaises(EnvironmentNotFoundError):
+            find_environment('session', '12345', 'test')
+
+    @mock.patch(
+        'cloud_snitch.remove.EnvironmentEntity.find',
+        return_value='testenv'
+    )
+    def test_find(self, m_find):
+        """Test that value from find_environment is returned on success."""
+        env = find_environment('session', '12345', 'test')
+        self.assertEqual(env, 'testenv')
+
+
+class TestConfirmEnvAction(unittest.TestCase):
+    """Test the confirm_env_action function."""
+
+    @mock.patch('builtins.input')
+    def test_skip_true(self, m_input):
+        """Test that input is skipped when skip is true."""
+        confirmed = confirm_env_action(
+            '12345',
+            'test_name',
+            'test_msg',
+            skip=True
+        )
+        m_input.assert_not_called()
+        self.assertTrue(confirmed)
+
+    @mock.patch('builtins.input', side_effect=['y'])
+    def test_skip_default(self, m_input):
+        """Test default behavior of skip(which is false)."""
+        confirmed = confirm_env_action('12345', 'test', 'test_msg')
+        m_input.assert_called_once_with('test_msg (y/n) --> ')
+        self.assertTrue(confirmed)
+
+    @mock.patch('builtins.input')
+    def test_loop_until_valid(self, m_input):
+        """Test loop until valid input."""
+        m_input.side_effect = ['a', 'b', 'c', 'Y']
+        confirmed = confirm_env_action('12345', 'test', 'test_msg')
+        self.assertTrue(confirmed)
+
+        m_input.side_effect = ['a', 'b', 'c', 'y']
+        confirmed = confirm_env_action('12345', 'test', 'test_msg')
+        self.assertTrue(confirmed)
+
+        m_input.side_effect = ['a', 'b', 'c', 'N']
+        confirmed = confirm_env_action('12345', 'test', 'test_msg')
+        self.assertFalse(confirmed)
+
+        m_input.side_effect = ['a', 'b', 'c', 'n']
+        confirmed = confirm_env_action('12345', 'test', 'test_msg')
+        self.assertFalse(confirmed)

--- a/cloud_snitch/tests/test_remove.py
+++ b/cloud_snitch/tests/test_remove.py
@@ -1,7 +1,9 @@
 import mock
+import sys
 import unittest
 
 from argparse import ArgumentError
+from io import StringIO
 
 from cloud_snitch.exc import EnvironmentNotFoundError
 from cloud_snitch.remove import confirm
@@ -13,6 +15,15 @@ from cloud_snitch.remove import prune
 
 class TestArgParser(unittest.TestCase):
     """Test the argument parser."""
+
+    def setUp(self):
+        self.old_stream = sys.stderr
+        self.stream = StringIO()
+        sys.stderr = self.stream
+
+    def tearDown(self):
+        sys.stderr = self.old_stream
+        self.stream.close()
 
     def test_missing_positionals(self):
         """Test with 0 args."""

--- a/cloud_snitch/tests/test_terminate.py
+++ b/cloud_snitch/tests/test_terminate.py
@@ -1,0 +1,151 @@
+import mock
+import unittest
+import sys
+
+from io import StringIO
+
+from cloud_snitch.terminate import parser
+from cloud_snitch.terminate import set_to_until_zero
+
+
+class TestArgParser(unittest.TestCase):
+
+    def setUp(self):
+        self.old_stream = sys.stderr
+        self.stream = StringIO()
+        sys.stderr = self.stream
+
+    def tearDown(self):
+        sys.stderr = self.old_stream
+        self.stream.close()
+
+    @mock.patch('cloud_snitch.utils.milliseconds_now')
+    def test_defaults(self, m_now):
+        """Test default arguments."""
+        m_now.return_value = 1
+        args = ['test_account_number', 'test_name']
+        args = parser.parse_args(args)
+        self.assertEqual(args.account_number, 'test_account_number')
+        self.assertEqual(args.name, 'test_name')
+        self.assertFalse(args.skip)
+        self.assertTrue(isinstance(args.time, int))
+        self.assertTrue(args.time > 0)
+        self.assertEqual(args.limit, 2000)
+
+    def test_non_defaults(self):
+        """Test non default arguments."""
+        # Test with -s option
+        args = ['test_account_number', 'test_name', '-s']
+        args = parser.parse_args(args)
+        self.assertTrue(args.skip)
+
+        # Test with --skip option
+        args = ['test_account_number', 'test_name', '--skip']
+        args = parser.parse_args(args)
+        self.assertTrue(args.skip)
+
+        # Test --time option
+        args = ['test_account_number', 'test_name', '--time', '33']
+        args = parser.parse_args(args)
+        self.assertEqual(args.time, 33)
+
+        # Test non integer --time option
+        args = ['test_account_number', 'test_name', '--time', 'notaint']
+        with self.assertRaises(SystemExit):
+            parser.parse_args(args)
+
+        # Test --limit option
+        args = ['test_account_number', 'test_name', '--limit', '100']
+        args = parser.parse_args(args)
+        self.assertEqual(args.limit, 100)
+
+        # Test non integer --limit option
+        args = ['test_account_number', 'test_name', '--limit', 'notaint']
+        with self.assertRaises(SystemExit):
+            parser.parse_args(args)
+
+
+class LoopStopperError(Exception):
+    pass
+
+
+class FakeResult(dict):
+    def __init__(self, changed):
+        self['changed'] = changed
+
+    def single(self):
+        return self
+
+
+class FakeTransaction:
+
+    def __init__(self, data, error_after=2):
+        self.data = data
+        self.error_after = error_after
+        self.calls = 0
+        self.query = None
+        self.params = None
+
+    def begin_transaction(self):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def run(self, query, **params):
+        self.calls += 1
+        if self.calls > self.error_after:
+            raise LoopStopperError("Stopping a loop")
+        self.query = query
+        self.params = params
+        return self.data[self.calls - 1]
+
+
+class FakeEnvironment:
+    def __init__(self, account_number="12345", name="testenv"):
+        self.account_number = account_number
+        self.name = name
+        self.account_number_name = "{}-{}".format(account_number, name)
+
+
+class TestSetToUntilZero(unittest.TestCase):
+    """Test delete_until_zero function."""
+
+    def test_cipher_params(self):
+        """Test that cipher query params are created."""
+        env = FakeEnvironment()
+
+        fake_tx = FakeTransaction([FakeResult(1)], error_after=1)
+        session = mock.Mock()
+        session.begin_transaction = mock.Mock()
+        session.begin_transaction.return_value = fake_tx
+
+        with self.assertRaises(LoopStopperError):
+            deleted = set_to_until_zero(session, env, 1, limit=5)
+
+        self.assertEqual(fake_tx.params['limit'], 5)
+        self.assertEqual(fake_tx.params['time'], 1)
+        self.assertEqual(
+            fake_tx.params['account_number_name'],
+            env.account_number_name
+        )
+
+    def test_loop_termination(self):
+        """Test that loop terminates when deleted count from query is 0."""
+        env = FakeEnvironment()
+        fake_results = [
+            FakeResult(10),
+            FakeResult(5),
+            FakeResult(1),
+            FakeResult(0)
+        ]
+        fake_tx = FakeTransaction(fake_results, error_after=10)
+        session = mock.Mock()
+        session.begin_transaction = mock.Mock()
+        session.begin_transaction.return_value = fake_tx
+
+        changed = set_to_until_zero(session, env, 1, limit=5)
+        self.assertEqual(changed, 16)

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ entry_points = """
     cloud-snitch-constraints=cloud_snitch.constraints:main
     cloud-snitch-clean=cloud_snitch.clean:main
     cloud-snitch-remove=cloud_snitch.remove:main
+    cloud-snitch-terminate=cloud_snitch.terminate:main
 """
 
 setup(


### PR DESCRIPTION
Termination is different from removal. Termination simply marks
the end of an environment.  All relationships that are still
current are set to either utcnow in milliseconds or to a specified
timestamp.

This is intended to be used for environments that no longer
physically exist and for enviroments with names that have changed.