### PR TITLE
Fixed ET-46.

### DIFF
--- a/installation/local/roles/web_install/defaults/main.yml
+++ b/installation/local/roles/web_install/defaults/main.yml
@@ -77,6 +77,7 @@ cloud_snitch_web_static_root: "{{ cloud_snitch_web_project_dir }}/static"
 cloud_snitch_web_pip_pkgs:
   django: 2.0.2
   djangorestframework: 3.8.2
+  djangorestframework-csv: 2.1.0
   neo4j-driver: 1.5.3
   celery: 4.1.1
   django-celery-results: 1.0.1

--- a/installation/local/roles/web_install/templates/settings.py.j2
+++ b/installation/local/roles/web_install/templates/settings.py.j2
@@ -241,5 +241,9 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
+    ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+        'rest_framework_csv.renderers.CSVRenderer',
     )
 }


### PR DESCRIPTION
Settings.py now includes list of valid renderers and
djangorestframework-csv is also installed as part of the ansible
web role.