### PR TITLE
Tags and vars fix

### DIFF
--- a/installation/local/roles/web_install/handlers/main.yml
+++ b/installation/local/roles/web_install/handlers/main.yml
@@ -5,7 +5,8 @@
     enabled: yes
     state: restarted
     daemon_reload: "{{ (ansible_service_mgr == 'systemd') | ternary ('yes', omit) }}"
-  when: not cloud_snitch_testenv
+  tags:
+    - service_restart
 
 - name: Restart Celery Worker
   service:
@@ -13,4 +14,5 @@
     enabled: yes
     state: restarted
     daemon_reload: "{{ (ansible_service_mgr == 'systemd') | ternary ('yes', omit) }}"
-  when: not cloud_snitch_testenv
+  tags:
+    - service_restart

--- a/installation/local/testenv_install.yml
+++ b/installation/local/testenv_install.yml
@@ -14,7 +14,6 @@
     crypt_backing_device: "{{ neo4j_crypt_backing_device }}"
     crypt_mount_point: "{{ neo4j_home }}"
     crypt_disk_password: "{{ pwsafe_neo4j_disk_password }}"
-    neo4j_data_dump_file: "/opt/neo4j_dump"
   tasks:
     - include_role:
         name: crypt
@@ -29,6 +28,8 @@
     - java
 
 - hosts: neo4j
+  vars:
+    neo4j_data_dump_file: "/opt/neo4j_dump"
   roles:
     - neo4j_install
   tags:


### PR DESCRIPTION
Need to allow skipping of service restarts based on tags instead of ansible vars (unit tests use playbooks to install packages and use skip-tags while testing deployment needs service restarts)

Also neo4j dump file belongs on neo4j role instead of crypt 