### PR TITLE
Added VersionedProperty object

### DIFF
--- a/cloud_snitch/exc.py
+++ b/cloud_snitch/exc.py
@@ -15,6 +15,11 @@ class PropertyAlreadyExistsError(Exception):
         super(PropertyAlreadyExistsError, self).__init__(msg)
 
 
+class EntityDefinitionError(Exception):
+    """Error for problems defining an entity."""
+    pass
+
+
 class RunInvalidError(Exception):
     """Error for a directory in the data directory that isn't a run."""
     def __init__(self, path):
@@ -98,3 +103,49 @@ class EnvironmentNotFoundError(Exception):
             '\'{}\' and name \'{}\'.'
         ).format(account_number, name)
         super(EnvironmentNotFoundError, self).__init__(msg)
+
+
+class ConversionError(Exception):
+    """Error for invalid conversion."""
+    def __init__(self, old_val, new_type):
+        """Init the error.
+
+        :param old_val: Old value to convert
+        :type old_val: object
+        :param new_type: New type to convert old value to
+        :type new_type: class
+        """
+        msg = (
+            'Unable to convert value \'{}\' to \'{}\'.'
+            .format(old_val, new_type)
+        )
+        super(ConversionError, self).__init__(msg)
+
+
+class ModelNotFoundError(Exception):
+    """Error for trying to get a model not in the registry."""
+    def __init__(self, model_name):
+        """Init the error.
+
+        :param model_name: Name of the model.
+        :type model_name: str
+        """
+        msg = 'Model \'{}\' not found.'.format(model_name)
+        super(ModelNotFoundError, self).__init__(msg)
+
+
+class PropertyNotFoundError(Exception):
+    """Error for property not existing on a model."""
+    def __init__(self, model_name, property_name):
+        """Init the error.
+
+        :param model_name: Name of the model
+        :type model_name: str
+        :param property_name: Name of the property
+        :type property_name: str
+        """
+        msg = (
+            'Property \'{}\' not found on model \'{}\'.'
+            .format(property_name, model_name)
+        )
+        super(PropertyNotFoundError, self).__init__(msg)

--- a/cloud_snitch/models/apt.py
+++ b/cloud_snitch/models/apt.py
@@ -1,23 +1,24 @@
 import logging
 
+from .base import versioned_properties
 from .base import SharedVersionedEntity
+from .base import VersionedProperty
 
 logger = logging.getLogger(__name__)
 
 
+@versioned_properties
 class AptPackageEntity(SharedVersionedEntity):
     """Model apt package nodes in the graph."""
 
     label = 'AptPackage'
     state_label = 'AptPackageState'
-    identity_property = 'name_version'
-    static_properties = [
-        'name',
-        'version'
-    ]
-    concat_properties = {
-        'name_version': [
-            'name',
-            'version'
-        ]
+
+    properties = {
+        'name_version': VersionedProperty(
+            is_identity=True,
+            concat_properties=['name', 'version']
+        ),
+        'name': VersionedProperty(is_static=True),
+        'version': VersionedProperty(is_static=True),
     }

--- a/cloud_snitch/models/configfile.py
+++ b/cloud_snitch/models/configfile.py
@@ -1,30 +1,27 @@
 import logging
 
+from .base import versioned_properties
 from .base import VersionedEntity
+from .base import VersionedProperty
 
 logger = logging.getLogger(__name__)
 
 
+@versioned_properties
 class ConfigfileEntity(VersionedEntity):
     """Model a configuration file in the graph."""
 
     label = 'Configfile'
     state_label = 'ConfigfileState'
-    identity_property = 'path_host'
-
-    static_properties = [
-        'path',
-        'host',
-        'name'
-    ]
-    state_properties = [
-        'md5',
-        'contents',
-        'is_binary'
-    ]
-    concat_properties = {
-        'path_host': [
-            'path',
-            'host'
-        ]
+    properties = {
+        'path_host': VersionedProperty(
+            is_identity=True,
+            concat_properties=['path', 'host']
+        ),
+        'path': VersionedProperty(is_static=True),
+        'host': VersionedProperty(is_static=True),
+        'name': VersionedProperty(is_static=True),
+        'md5': VersionedProperty(is_state=True),
+        'contents': VersionedProperty(is_state=True),
+        'is_binary': VersionedProperty(is_state=True)
     }

--- a/cloud_snitch/models/environment.py
+++ b/cloud_snitch/models/environment.py
@@ -1,6 +1,8 @@
 import logging
 
+from .base import versioned_properties
 from .base import VersionedEntity
+from .base import VersionedProperty
 from .host import HostEntity
 from .gitrepo import GitRepoEntity
 from .uservar import UservarEntity
@@ -8,21 +10,19 @@ from .uservar import UservarEntity
 logger = logging.getLogger(__name__)
 
 
+@versioned_properties
 class EnvironmentEntity(VersionedEntity):
     """Model environment nodes in the graph."""
 
     label = 'Environment'
     state_label = 'EnvironmentState'
-    identity_property = 'account_number_name'
-    static_properties = [
-        'account_number',
-        'name',
-    ]
-    concat_properties = {
-        'account_number_name': [
-            'account_number',
-            'name'
-        ]
+    properties = {
+        'account_number_name': VersionedProperty(
+            is_identity=True,
+            concat_properties=['account_number', 'name']
+        ),
+        'account_number': VersionedProperty(is_static=True),
+        'name': VersionedProperty(is_static=True)
     }
 
     children = {

--- a/cloud_snitch/models/environmentlock.py
+++ b/cloud_snitch/models/environmentlock.py
@@ -1,12 +1,15 @@
 import logging
 
+from .base import versioned_properties
 from .base import VersionedEntity
+from .base import VersionedProperty
 from cloud_snitch import utils
 from cloud_snitch.exc import EnvironmentLockedError
 
 logger = logging.getLogger(__name__)
 
 
+@versioned_properties
 class EnvironmentLockEntity(VersionedEntity):
     """Model an environment lock in the graph.
 
@@ -16,17 +19,14 @@ class EnvironmentLockEntity(VersionedEntity):
 
     label = 'EnvironmentLock'
     state_label = 'EnvironmentLockState'
-    identity_property = 'account_number_name'
-    static_properties = [
-        'account_number',
-        'name',
-        'locked'
-    ]
-    concat_properties = {
-        'account_number_name': [
-            'account_number',
-            'name'
-        ]
+    properties = {
+        'account_number_name': VersionedProperty(
+            is_identity=True,
+            concat_properties=['account_number', 'name']
+        ),
+        'account_number': VersionedProperty(is_static=True),
+        'name': VersionedProperty(is_static=True),
+        'locked': VersionedProperty(is_static=True, type=int)
     }
 
     @classmethod

--- a/cloud_snitch/models/gitrepo.py
+++ b/cloud_snitch/models/gitrepo.py
@@ -1,73 +1,74 @@
 import logging
 
+from .base import versioned_properties
 from .base import SharedVersionedEntity
 from .base import VersionedEntity
+from .base import VersionedProperty
 
 logger = logging.getLogger(__name__)
 
 
-class GitUntrackedFileEntity(VersionedEntity):
+@versioned_properties
+class GitUntrackedFileEntity(SharedVersionedEntity):
     """Models an untracked file in a gitrepo."""
 
     label = 'GitUntrackedFile'
-    state_label = 'GitUntrackedFile'
-    identity_property = 'path'
+    state_label = 'GitUntrackedFileState'
+    properties = {
+        'path': VersionedProperty(is_identity=True)
+    }
 
 
+@versioned_properties
 class GitUrlEntity(SharedVersionedEntity):
     """Models a git repo url."""
 
     label = 'GitUrl'
     state_label = 'GitUrlState'
-    identity_property = 'url'
+    properties = {
+        'url': VersionedProperty(is_identity=True)
+    }
 
 
+@versioned_properties
 class GitRemoteEntity(VersionedEntity):
     """Models a git repo remote."""
 
     label = 'GitRemote'
     state_label = 'GitRemoteState'
-    identity_property = 'name_repo'
-    static_properties = [
-        'name',
-        'repo'
-    ]
-    concat_properties = {
-        'name_repo': [
-            'name',
-            'repo'
-        ]
+    properties = {
+        'name_repo': VersionedProperty(
+            is_identity=True,
+            concat_properties=['name', 'repo']
+        ),
+        'name': VersionedProperty(is_static=True),
+        'repo': VersionedProperty(is_static=True)
     }
-
     children = {
         'urls': ('HAS_GIT_URL', GitUrlEntity)
     }
 
 
+@versioned_properties
 class GitRepoEntity(VersionedEntity):
     """Models a git repo."""
 
     label = 'GitRepo'
     state_label = 'GitRepoState'
-    identity_property = 'path_environment'
-    static_properties = [
-        'path',
-        'environment'
-    ]
-    state_properties = [
-        'active_branch_name',
-        'head_sha',
-        'is_detached',
-        'working_tree_dirty',
-        'working_tree_diff_md5',
-        'merge_base_name',
-        'merge_base_diff_md5'
-    ]
-    concat_properties = {
-        'path_environment': [
-            'path',
-            'environment'
-        ]
+    properties = {
+        'path_environment': VersionedProperty(
+            is_identity=True,
+            concat_properties=['path', 'environment']
+        ),
+        'path': VersionedProperty(is_static=True),
+        'environment': VersionedProperty(is_static=True),
+        'active_branch_name': VersionedProperty(is_state=True),
+        'head_sha': VersionedProperty(is_state=True),
+        'is_detached': VersionedProperty(is_state=True),
+        'working_tree_dirty': VersionedProperty(is_state=True),
+        'working_tree_diff_md5': VersionedProperty(is_state=True),
+        'merge_base_name': VersionedProperty(is_state=True),
+        'merge_base_diff_md5': VersionedProperty(is_state=True)
     }
 
     children = {

--- a/cloud_snitch/models/host.py
+++ b/cloud_snitch/models/host.py
@@ -1,7 +1,9 @@
 import logging
 
+from .base import versioned_properties
 from .base import SharedVersionedEntity
 from .base import VersionedEntity
+from .base import VersionedProperty
 from .apt import AptPackageEntity
 from .configfile import ConfigfileEntity
 from .virtualenv import VirtualenvEntity
@@ -9,202 +11,167 @@ from .virtualenv import VirtualenvEntity
 logger = logging.getLogger(__name__)
 
 
+@versioned_properties
 class NameServerEntity(SharedVersionedEntity):
     """Model a name server node in the graph."""
-
     label = 'NameServer'
     state_label = 'NameServerState'
-    identity_property = 'ip'
+    properties = {
+        'ip': VersionedProperty(is_identity=True)
+    }
 
 
+@versioned_properties
 class PartitionEntity(VersionedEntity):
     """Model a partition on a device in the graph."""
 
     label = 'Partition'
     state_label = 'PartitionState'
-    identity_property = 'name_device'
-
-    static_properties = [
-        'name',
-        'device'
-    ]
-
-    state_properties = [
-        'size',
-        'start'
-    ]
-
-    concat_properties = {
-        'name_device': [
-            'name',
-            'device'
-        ]
+    properties = {
+        'name_device': VersionedProperty(
+            is_identity=True,
+            concat_properties=['name', 'device']
+        ),
+        'name': VersionedProperty(is_static=True),
+        'device': VersionedProperty(is_static=True),
+        'size': VersionedProperty(is_state=True),
+        'start': VersionedProperty(is_state=True)
     }
 
 
+@versioned_properties
 class DeviceEntity(VersionedEntity):
     """Model a device node in the graph."""
 
     label = 'Device'
     state_label = 'DeviceState'
-    identity_property = 'name_host'
-
-    static_properties = [
-        'name',
-        'host',
-    ]
-
-    state_properties = [
-        'removable',
-        'rotational',
-        'size'
-    ]
-
-    concat_properties = {
-        'name_host': [
-            'name',
-            'host'
-        ]
+    properties = {
+        'name_host': VersionedProperty(
+            is_identity=True,
+            concat_properties=['name', 'host']
+        ),
+        'name': VersionedProperty(is_static=True),
+        'host': VersionedProperty(is_static=True),
+        'removable': VersionedProperty(is_state=True),
+        'rotational': VersionedProperty(is_state=True),
+        'size': VersionedProperty(is_state=True)
     }
-
     children = {
         'partitions': ('HAS_PARTITION', PartitionEntity)
     }
 
 
+@versioned_properties
 class MountEntity(VersionedEntity):
     """Model a mount node in the graph."""
 
     label = 'Mount'
     state_label = 'MountState'
-    identity_property = 'mount_host'
-
-    static_properties = [
-        'mount',
-        'host',
-    ]
-
-    state_properties = [
-        'device',
-        'size_total',
-        'fstype'
-    ]
-
-    concat_properties = {
-        'mount_host': [
-            'mount',
-            'host'
-        ]
+    properties = {
+        'mount_host': VersionedProperty(
+            is_identity=True,
+            concat_properties=['mount', 'host']
+        ),
+        'mount': VersionedProperty(is_static=True),
+        'host': VersionedProperty(is_static=True),
+        'device': VersionedProperty(is_state=True),
+        'size_total': VersionedProperty(is_state=True),
+        'fstype': VersionedProperty(is_state=True)
     }
 
 
+@versioned_properties
 class InterfaceEntity(VersionedEntity):
     """Model interface nodes in the graph."""
 
     label = 'Interface'
     state_label = 'InterfaceState'
-    identity_property = 'device_host'
-
-    static_properties = [
-        'device',
-        'host'
-    ]
-
-    state_properties = [
-        'active',
-        'ipv4_address',
-        'ipv6_address',
-        'macaddress',
-        'mtu',
-        'promisc',
-        'type'
-    ]
-
-    concat_properties = {
-        'device_host': [
-            'device',
-            'host'
-        ]
+    properties = {
+        'device_host': VersionedProperty(
+            is_identity=True,
+            concat_properties=['device', 'host']
+        ),
+        'device': VersionedProperty(is_static=True),
+        'host': VersionedProperty(is_static=True),
+        'active': VersionedProperty(is_state=True),
+        'ipv4_address': VersionedProperty(is_state=True),
+        'ipv6_address': VersionedProperty(is_state=True),
+        'macaddress': VersionedProperty(is_state=True),
+        'mtu': VersionedProperty(is_state=True, type=int),
+        'promisc': VersionedProperty(is_state=True),
+        'type': VersionedProperty(is_state=True)
     }
 
 
+@versioned_properties
 class ConfiguredInterfaceEntity(VersionedEntity):
     """Model a ConfiguredInterface in the graph."""
 
     label = 'ConfiguredInterface'
     state_label = 'ConfiguredInterfaceState'
-    identity_property = 'device_host'
-
-    static_properties = [
-        'device',
-        'host'
-    ]
-    state_properties = [
-        'mtu',
-        'offload_sg',
-        'bridge_waitport',
-        'bridge_fd',
-        'bridge_ports',
-        'bridge_stp',
-        'address',
-        'netmask',
-        'dns_nameservers',
-        'gateway'
-    ]
-    concat_properties = {
-        'device_host': [
-            'device',
-            'host'
-        ]
+    properties = {
+        'device_host': VersionedProperty(
+            is_identity=True,
+            concat_properties=['device', 'host']
+        ),
+        'device': VersionedProperty(is_static=True),
+        'host': VersionedProperty(is_static=True),
+        'mtu': VersionedProperty(is_state=True, type=int),
+        'offload_sg': VersionedProperty(is_state=True),
+        'bridge_waitport': VersionedProperty(is_state=True),
+        'bridge_fd': VersionedProperty(is_state=True),
+        'bridge_ports': VersionedProperty(is_state=True),
+        'bridge_stp': VersionedProperty(is_state=True),
+        'address': VersionedProperty(is_state=True),
+        'netmask': VersionedProperty(is_state=True),
+        'dns_nameservers': VersionedProperty(is_state=True),
+        'gateway': VersionedProperty(is_state=True)
     }
 
 
+@versioned_properties
 class HostEntity(VersionedEntity):
     """Model host nodes in the graph."""
 
     label = 'Host'
     state_label = 'HostState'
-    identity_property = 'hostname_environment'
 
-    static_properties = [
-        'hostname',
-        'environment'
-    ]
+    properties = {
+        'hostname_environment': VersionedProperty(
+            is_identity=True,
+            concat_properties=['hostname', 'environment']
+        ),
+        'hostname': VersionedProperty(is_static=True),
+        'environment': VersionedProperty(is_static=True),
 
-    concat_properties = {
-        'hostname_environment': [
-            'hostname',
-            'environment'
-        ]
+        'architecture': VersionedProperty(is_state=True),
+        'bios_date': VersionedProperty(is_state=True),
+        'bios_version': VersionedProperty(is_state=True),
+        'default_ipv4_address': VersionedProperty(is_state=True),
+        'default_ipv6_address': VersionedProperty(is_state=True),
+        'kernel': VersionedProperty(is_state=True),
+        'memtotal_mb': VersionedProperty(is_state=True, type=int),
+        'lsb_codename': VersionedProperty(is_state=True),
+        'lsb_description': VersionedProperty(is_state=True),
+        'lsb_id': VersionedProperty(is_state=True),
+        'lsb_major_release': VersionedProperty(is_state=True),
+        'lsb_release': VersionedProperty(is_state=True),
+        'fqdn': VersionedProperty(is_state=True),
+        'pkg_mgr': VersionedProperty(is_state=True),
+        'processor_cores': VersionedProperty(is_state=True, type=int),
+        'processor_count': VersionedProperty(is_state=True, type=int),
+        'processor_threads_per_core': VersionedProperty(
+            is_state=True,
+            type=int
+        ),
+        'processor_vcpus': VersionedProperty(is_state=True, type=int),
+        'python_executable': VersionedProperty(is_state=True),
+        'python_version': VersionedProperty(is_state=True),
+        'python_type': VersionedProperty(is_state=True),
+        'service_mgr': VersionedProperty(is_state=True),
+        'selinux': VersionedProperty(is_state=True, type=bool),
+        'ansible_version_full': VersionedProperty(is_state=True)
     }
-
-    state_properties = [
-        'architecture',
-        'bios_date',
-        'bios_version',
-        'default_ipv4_address',
-        'default_ipv6_address',
-        'kernel',
-        'memtotal_mb',
-        'lsb_codename',
-        'lsb_description',
-        'lsb_id',
-        'lsb_major_release',
-        'lsb_release',
-        'fqdn',
-        'pkg_mgr',
-        'processor_cores',
-        'processor_count',
-        'processor_threads_per_core',
-        'processor_vcpus',
-        'python_executable',
-        'python_version',
-        'python_type',
-        'service_mgr',
-        'selinux',
-        'ansible_version_full'
-    ]
-
     children = {
         'aptpackages': ('HAS_APT_PACKAGE', AptPackageEntity),
         'virtualenvs': ('HAS_VIRTUALENV', VirtualenvEntity),

--- a/cloud_snitch/models/uservar.py
+++ b/cloud_snitch/models/uservar.py
@@ -1,27 +1,23 @@
 import logging
 
+from .base import versioned_properties
 from .base import VersionedEntity
+from .base import VersionedProperty
 
 logger = logging.getLogger(__name__)
 
 
+@versioned_properties
 class UservarEntity(VersionedEntity):
     """Models a user variable."""
-
     label = 'Uservar'
     state_label = 'UservarState'
-
-    identity_property = 'name_environment'
-    static_properties = [
-        'name',
-        'environment'
-    ]
-    state_properties = [
-        'value'
-    ]
-    concat_properties = {
-        'name_environment': [
-            'name',
-            'environment'
-        ]
+    properties = {
+        'name_environment': VersionedProperty(
+            is_identity=True,
+            concat_properties=['name', 'environment']
+        ),
+        'name': VersionedProperty(is_static=True),
+        'environment': VersionedProperty(is_static=True),
+        'value': VersionedProperty(is_state=True)
     }

--- a/cloud_snitch/models/utils.py
+++ b/cloud_snitch/models/utils.py
@@ -1,0 +1,72 @@
+from cloud_snitch.exc import ConversionError
+from cloud_snitch.exc import ModelNotFoundError
+from cloud_snitch.exc import PropertyNotFoundError
+from cloud_snitch.models import registry
+
+_falses = set(['false', 'no'])
+
+
+def string_to_bool(value):
+    if not value:
+        return False
+
+    if value.lower() in _falses:
+        return False
+
+    return True
+
+
+SPECIAL_CONVERSIONS = {
+    str: {
+        bool: string_to_bool
+    }
+}
+
+
+def prep_val(model_name, prop_name, value, raise_for_error=True):
+    """Try to convert value to a datatype to match the property.
+
+    :param model_name: Name of the model or label
+    :type model_name: str
+    :param prop_name: Name of the property
+    :type prop_name: str
+    :param value: Value to prepare
+    :type value: str
+    :param raise_for_error: Raise an exception on conversion error.
+        If set to false, the original value will be returned.
+        Errors for missing models or properties will always be raised.
+    :type raise_for_error: bool
+    :returns: Converted value
+    :rtype: type of property
+    """
+    # Get model object
+    model = registry.models.get(model_name)
+    if model is None:
+        raise ModelNotFoundError(model_name)
+
+    # Get property type
+    try:
+        t = model.properties[prop_name].type
+    except KeyError:
+        raise PropertyNotFoundError(model_name, prop_name)
+
+    # If value is already the desired type, do nothing.
+    if isinstance(value, t):
+        return value
+
+    # Look for a special conversion
+    try:
+        conversion = SPECIAL_CONVERSIONS[type(value)][t]
+    except KeyError:
+        conversion = t
+
+    # Attempt simple conversion.
+    try:
+        new_val = conversion(value)
+    except Exception:
+        if raise_for_error:
+            raise ConversionError(value, t)
+        new_val = value
+
+    # Return the new value.
+    return new_val

--- a/cloud_snitch/models/virtualenv.py
+++ b/cloud_snitch/models/virtualenv.py
@@ -1,43 +1,41 @@
 import logging
 
+from .base import versioned_properties
 from .base import SharedVersionedEntity
 from .base import VersionedEntity
+from .base import VersionedProperty
 
 logger = logging.getLogger(__name__)
 
 
+@versioned_properties
 class PythonPackageEntity(SharedVersionedEntity):
     """Model pythonpackage nodes in the graph."""
-
     label = 'PythonPackage'
     state_label = 'PythonPackageState'
-    identity_property = 'name_version'
-    static_properties = ['name', 'version']
-    concat_properties = {
-        'name_version': [
-            'name',
-            'version'
-        ]
+    properties = {
+        'name_version': VersionedProperty(
+            is_identity=True,
+            concat_properties=['name', 'version']
+        ),
+        'name': VersionedProperty(is_static=True),
+        'version': VersionedProperty(is_static=True)
     }
 
 
+@versioned_properties
 class VirtualenvEntity(VersionedEntity):
     """Model virtualenv nodes in the graph."""
-
     label = 'Virtualenv'
     state_label = 'VirtualenvState'
-    identity_property = 'path_host'
-    static_properties = [
-        'path',
-        'host'
-    ]
-    concat_properties = {
-        'path_host': [
-            'path',
-            'host'
-        ]
+    properties = {
+        'path_host': VersionedProperty(
+            is_identity=True,
+            concat_properties=['path', 'host']
+        ),
+        'path': VersionedProperty(is_static=True),
+        'host': VersionedProperty(is_static=True)
     }
-
     children = {
         'pythonpackages': ('HAS_PYTHON_PACKAGE', PythonPackageEntity)
     }

--- a/cloud_snitch/tests/models/base.py
+++ b/cloud_snitch/tests/models/base.py
@@ -1,0 +1,63 @@
+import unittest
+
+
+class DefinitionTestCase(unittest.TestCase):
+    """Subclass this to test entity definitions."""
+
+    label = 'somelabel'
+    state_label = 'somelabelstate'
+    identity_property = 'some_identity_property'
+    static_properties = []
+    state_properties = []
+    concat_properties = {}
+    children = {}
+
+    entity = None
+
+    def definition_test(self):
+        """Test definition."""
+        self.assertEqual(self.entity.label, self.label)
+        self.assertEqual(self.entity.state_label, self.state_label)
+
+        # Test identity property
+        self.assertEqual(
+            self.entity.identity_property,
+            self.identity_property
+        )
+
+        # Test static properties
+        for prop in self.static_properties:
+            self.assertTrue(prop in self.entity.static_properties)
+        self.assertEqual(
+            len(self.entity.static_properties),
+            len(self.static_properties)
+        )
+
+        # Test state properties
+        for prop in self.state_properties:
+            self.assertTrue(prop in self.entity.state_properties)
+        self.assertEqual(
+            len(self.entity.state_properties),
+            len(self.state_properties)
+        )
+
+        # Test concat properies
+        for prop_name, prop_list in self.concat_properties.items():
+            for i, prop in enumerate(prop_list):
+                self.assertEqual(
+                    self.entity.concat_properties[prop_name][i],
+                    prop
+                )
+            self.assertEqual(
+                len(self.entity.concat_properties[prop_name]),
+                len(prop_list)
+            )
+        self.assertEqual(
+            len(self.entity.concat_properties),
+            len(self.concat_properties)
+        )
+
+        # Test children
+        for name, tup in self.children:
+            self.assertEqual(self.entity.children[name], tup)
+        self.assertEqual(len(self.entity.children), len(self.children))

--- a/cloud_snitch/tests/models/test_apt.py
+++ b/cloud_snitch/tests/models/test_apt.py
@@ -1,0 +1,27 @@
+import unittest
+
+from .base import DefinitionTestCase
+
+from cloud_snitch.models import AptPackageEntity
+
+
+class TestAptPackageEntity(DefinitionTestCase):
+    """Test the apt package entity definition."""
+    entity = AptPackageEntity
+    label = 'AptPackage'
+    state_label = 'AptPackageState'
+    identity_property = 'name_version'
+    static_properties = [
+        'name',
+        'version'
+    ]
+    concat_properties = {
+        'name_version': [
+            'name',
+            'version'
+        ]
+    }
+
+    def test_definition(self):
+        """Test definition."""
+        self.definition_test()

--- a/cloud_snitch/tests/models/test_configfile.py
+++ b/cloud_snitch/tests/models/test_configfile.py
@@ -1,0 +1,32 @@
+import unittest
+
+from .base import DefinitionTestCase
+from cloud_snitch.models import ConfigfileEntity
+
+
+class TestConfigfileEntity(DefinitionTestCase):
+    """Test the config file entity definition."""
+    entity = ConfigfileEntity
+    label = 'Configfile'
+    state_label = 'ConfigfileState'
+    identity_property = 'path_host'
+    static_properties = [
+        'path',
+        'host',
+        'name'
+    ]
+    state_properties = [
+        'md5',
+        'contents',
+        'is_binary'
+    ]
+    concat_properties = {
+        'path_host': [
+            'path',
+            'host'
+        ]
+    }
+
+    def test_definition(self):
+        """Test definition."""
+        self.definition_test()

--- a/cloud_snitch/tests/models/test_environment.py
+++ b/cloud_snitch/tests/models/test_environment.py
@@ -1,0 +1,34 @@
+import unittest
+
+from .base import DefinitionTestCase
+from cloud_snitch.models import EnvironmentEntity
+from cloud_snitch.models import GitRepoEntity
+from cloud_snitch.models import HostEntity
+from cloud_snitch.models import UservarEntity
+
+
+class TestEnvironmentEntity(DefinitionTestCase):
+    """Test the environment entity definition."""
+    entity = EnvironmentEntity
+    label = 'Environment'
+    state_label = 'EnvironmentState'
+    identity_property = 'account_number_name'
+    static_properties = [
+        'account_number',
+        'name',
+    ]
+    concat_properties = {
+        'account_number_name': [
+            'account_number',
+            'name'
+        ]
+    }
+    children = (
+        ('hosts', ('HAS_HOST', HostEntity)),
+        ('gitrepos', ('HAS_GIT_REPO', GitRepoEntity)),
+        ('uservars', ('HAS_USERVAR', UservarEntity))
+    )
+
+    def test_definition(self):
+        """Test definition."""
+        self.definition_test()

--- a/cloud_snitch/tests/models/test_environmentlock.py
+++ b/cloud_snitch/tests/models/test_environmentlock.py
@@ -1,0 +1,27 @@
+import unittest
+
+from .base import DefinitionTestCase
+from cloud_snitch.models import EnvironmentLockEntity
+
+
+class TestEnvironmentEntity(DefinitionTestCase):
+    """Test the environment entity definition."""
+    entity = EnvironmentLockEntity
+    label = 'EnvironmentLock'
+    state_label = 'EnvironmentLockState'
+    identity_property = 'account_number_name'
+    static_properties = [
+        'account_number',
+        'name',
+        'locked'
+    ]
+    concat_properties = {
+        'account_number_name': [
+            'account_number',
+            'name'
+        ]
+    }
+
+    def test_definition(self):
+        """Test definition."""
+        self.definition_test()

--- a/cloud_snitch/tests/models/test_gitrepo.py
+++ b/cloud_snitch/tests/models/test_gitrepo.py
@@ -1,0 +1,91 @@
+import unittest
+
+from .base import DefinitionTestCase
+from cloud_snitch.models import GitRemoteEntity
+from cloud_snitch.models import GitRepoEntity
+from cloud_snitch.models import GitUntrackedFileEntity
+from cloud_snitch.models import GitUrlEntity
+
+
+class TestGitUntrackedFileEntity(DefinitionTestCase):
+    """Test the git untracked file entity definition."""
+    entity = GitUntrackedFileEntity
+    label = 'GitUntrackedFile'
+    state_label = 'GitUntrackedFileState'
+    identity_property = 'path'
+
+    def test_definition(self):
+        """Test definition."""
+        self.definition_test()
+
+
+class TestGitUrlEntity(DefinitionTestCase):
+    """Test the git url entity definition."""
+    entity = GitUrlEntity
+    label = 'GitUrl'
+    state_label = 'GitUrlState'
+    identity_property = 'url'
+
+    def test_definition(self):
+        """Test definition."""
+        self.definition_test()
+
+
+class TestGitRemoteEntity(DefinitionTestCase):
+    """Test the git remote entity definition."""
+    entity = GitRemoteEntity
+    label = 'GitRemote'
+    state_label = 'GitRemoteState'
+    identity_property = 'name_repo'
+    static_properties = [
+        'name',
+        'repo'
+    ]
+    concat_properties = {
+        'name_repo': [
+            'name',
+            'repo'
+        ]
+    }
+    children = (
+        ('urls', ('HAS_GIT_URL', GitUrlEntity)),
+    )
+
+    def test_definition(self):
+        """Test definition."""
+        self.definition_test()
+
+
+class TestGitRepoEntity(DefinitionTestCase):
+    """Test the git repo entity definition."""
+    entity = GitRepoEntity
+    label = 'GitRepo'
+    state_label = 'GitRepoState'
+    identity_property = 'path_environment'
+    static_properties = [
+        'path',
+        'environment'
+    ]
+    state_properties = [
+        'active_branch_name',
+        'head_sha',
+        'is_detached',
+        'working_tree_dirty',
+        'working_tree_diff_md5',
+        'merge_base_name',
+        'merge_base_diff_md5'
+    ]
+    concat_properties = {
+        'path_environment': [
+            'path',
+            'environment'
+        ]
+    }
+    children = (
+        ('untrackedfiles', ('HAS_UNTRACKED_FILE', GitUntrackedFileEntity)),
+        ('remotes', ('HAS_GIT_REMOTE', GitRemoteEntity))
+    )
+
+    def test_definition(self):
+        """Test definition."""
+        self.definition_test()

--- a/cloud_snitch/tests/models/test_host.py
+++ b/cloud_snitch/tests/models/test_host.py
@@ -1,0 +1,239 @@
+import unittest
+
+from .base import DefinitionTestCase
+
+from cloud_snitch.models import AptPackageEntity
+from cloud_snitch.models import DeviceEntity
+from cloud_snitch.models import ConfigfileEntity
+from cloud_snitch.models import ConfiguredInterfaceEntity
+from cloud_snitch.models import HostEntity
+from cloud_snitch.models import InterfaceEntity
+from cloud_snitch.models import MountEntity
+from cloud_snitch.models import NameServerEntity
+from cloud_snitch.models import PartitionEntity
+from cloud_snitch.models import VirtualenvEntity
+
+
+class TestNameServerEntity(DefinitionTestCase):
+    """Test the name server entity definition."""
+    entity = NameServerEntity
+    label = 'NameServer'
+    state_label = 'NameServerState'
+    identity_property = 'ip'
+
+    def test_definition(self):
+        """Test definition."""
+        self.definition_test()
+
+
+class TestPartitionEntity(DefinitionTestCase):
+    """Test the partition entity definition."""
+    entity = PartitionEntity
+    label = 'Partition'
+    state_label = 'PartitionState'
+    identity_property = 'name_device'
+    static_properties = [
+        'name',
+        'device'
+    ]
+    state_properties = [
+        'size',
+        'start'
+    ]
+    concat_properties = {
+        'name_device': [
+            'name',
+            'device'
+        ]
+    }
+
+    def test_definition(self):
+        """Test definition."""
+        self.definition_test()
+
+
+class TestDeviceEntity(DefinitionTestCase):
+    """Test the device entity definition."""
+    entity = DeviceEntity
+    label = 'Device'
+    state_label = 'DeviceState'
+    identity_property = 'name_host'
+    static_properties = [
+        'name',
+        'host',
+    ]
+    state_properties = [
+        'removable',
+        'rotational',
+        'size'
+    ]
+    concat_properties = {
+        'name_host': [
+            'name',
+            'host'
+        ]
+    }
+    children = (
+        ('partitions', ('HAS_PARTITION', PartitionEntity)),
+    )
+
+    def test_definition(self):
+        """Test definition."""
+        self.definition_test()
+
+
+class TestMountEntity(DefinitionTestCase):
+    """Test the mount entity definition."""
+    entity = MountEntity
+    label = 'Mount'
+    state_label = 'MountState'
+    identity_property = 'mount_host'
+    static_properties = [
+        'mount',
+        'host',
+    ]
+    state_properties = [
+        'device',
+        'size_total',
+        'fstype'
+    ]
+    concat_properties = {
+        'mount_host': [
+            'mount',
+            'host'
+        ]
+    }
+
+    def test_definition(self):
+        """Test definition."""
+        self.definition_test()
+
+
+class TestInterfaceDefinition(DefinitionTestCase):
+    """Test the interface entity definition."""
+    entity = InterfaceEntity
+    label = 'Interface'
+    state_label = 'InterfaceState'
+    identity_property = 'device_host'
+    static_properties = [
+        'device',
+        'host'
+    ]
+    state_properties = [
+        'active',
+        'ipv4_address',
+        'ipv6_address',
+        'macaddress',
+        'mtu',
+        'promisc',
+        'type'
+    ]
+    concat_properties = {
+        'device_host': [
+            'device',
+            'host'
+        ]
+    }
+
+    def test_definition(self):
+        """Test defition."""
+        self.definition_test()
+
+
+class TestConfiguredInterfaceDefinition(DefinitionTestCase):
+    """Test the configured interface entity definition."""
+
+    entity = ConfiguredInterfaceEntity
+    label = 'ConfiguredInterface'
+    state_label = 'ConfiguredInterfaceState'
+    identity_property = 'device_host'
+    static_properties = [
+        'device',
+        'host'
+    ]
+    state_properties = [
+        'mtu',
+        'offload_sg',
+        'bridge_waitport',
+        'bridge_fd',
+        'bridge_ports',
+        'bridge_stp',
+        'address',
+        'netmask',
+        'dns_nameservers',
+        'gateway'
+    ]
+    concat_properties = {
+        'device_host': ['device', 'host']
+    }
+
+    def test_definition(self):
+        self.definition_test()
+
+
+class TestHostDefinition(DefinitionTestCase):
+
+    entity = HostEntity
+
+    label = 'Host'
+    state_label = 'HostState'
+
+    identity_property = 'hostname_environment'
+    static_properties = [
+        'hostname',
+        'environment'
+    ]
+
+    state_properties = [
+        'architecture',
+        'bios_date',
+        'bios_version',
+        'default_ipv4_address',
+        'default_ipv6_address',
+        'kernel',
+        'memtotal_mb',
+        'lsb_codename',
+        'lsb_description',
+        'lsb_id',
+        'lsb_major_release',
+        'lsb_release',
+        'fqdn',
+        'pkg_mgr',
+        'processor_cores',
+        'processor_count',
+        'processor_threads_per_core',
+        'processor_vcpus',
+        'python_executable',
+        'python_version',
+        'python_type',
+        'service_mgr',
+        'selinux',
+        'ansible_version_full'
+    ]
+
+    concat_properties = {
+        'hostname_environment': [
+            'hostname',
+            'environment'
+        ]
+    }
+
+    children = (
+        ('aptpackages', ('HAS_APT_PACKAGE', AptPackageEntity)),
+        ('virtualenvs', ('HAS_VIRTUALENV', VirtualenvEntity)),
+        ('configfiles', ('HAS_CONFIG_FILE', ConfigfileEntity)),
+        ('nameservers', ('HAS_NAMESERVER', NameServerEntity)),
+        ('interfaces', ('HAS_INTERFACE', InterfaceEntity)),
+        ('mounts', ('HAS_MOUNT', MountEntity)),
+        ('devices', ('HAS_DEVICE', DeviceEntity)),
+        (
+            'configuredinterfaces', (
+                'HAS_CONFIGURED_INTERFACE',
+                ConfiguredInterfaceEntity
+            )
+        )
+    )
+
+    def test_definition(self):
+        """Test the definition."""
+        self.definition_test()

--- a/cloud_snitch/tests/models/test_uservar.py
+++ b/cloud_snitch/tests/models/test_uservar.py
@@ -1,0 +1,28 @@
+from .base import DefinitionTestCase
+
+from cloud_snitch.models import UservarEntity
+
+
+class TestUservarDefinition(DefinitionTestCase):
+    """Test uservar definition."""
+    entity = UservarEntity
+    label = 'Uservar'
+    state_label = 'UservarState'
+    identity_property = 'name_environment'
+    static_properties = [
+        'name',
+        'environment'
+    ]
+    state_properties = [
+        'value'
+    ]
+    concat_properties = {
+        'name_environment': [
+            'name',
+            'environment'
+        ]
+    }
+
+    def test_definition(self):
+        """Test the definition."""
+        self.definition_test()

--- a/cloud_snitch/tests/models/test_utils.py
+++ b/cloud_snitch/tests/models/test_utils.py
@@ -1,0 +1,131 @@
+import mock
+import unittest
+
+from cloud_snitch.exc import ConversionError
+from cloud_snitch.exc import ModelNotFoundError
+from cloud_snitch.exc import PropertyNotFoundError
+
+from cloud_snitch.models.base import VersionedProperty
+from cloud_snitch.models.utils import prep_val
+from cloud_snitch.models.utils import string_to_bool
+
+
+class TestStringToBool(unittest.TestCase):
+    def test_empty_string(self):
+        """Test that the empty string returns False."""
+        self.assertFalse(string_to_bool(''))
+
+    def test_non_standard_text(self):
+        """Test that unexpected strings are True."""
+        self.assertTrue(string_to_bool('anythingelse'))
+
+    def test_trues(self):
+        """Test that true, TRUE, yes, YES are true."""
+        self.assertTrue(string_to_bool('true'))
+        self.assertTrue(string_to_bool('TRUE'))
+        self.assertTrue(string_to_bool('yes'))
+        self.assertTrue(string_to_bool('YES'))
+
+    def test_falses(self):
+        """Test that false, FALSE, no, No are false."""
+        self.assertFalse(string_to_bool('false'))
+        self.assertFalse(string_to_bool('FALSE'))
+        self.assertFalse(string_to_bool('no'))
+        self.assertFalse(string_to_bool('NO'))
+
+
+class TestPrepVal(unittest.TestCase):
+
+    def test_invalid_model(self):
+        """Test that ModelNotFoundError is raised."""
+        # Test with raise_for_error=True
+        with self.assertRaises(ModelNotFoundError):
+            prep_val('m', 'p', 'somevalue', raise_for_error=True)
+
+        # Test without raise_for_error(should still raise for this error.)
+        with self.assertRaises(ModelNotFoundError):
+            prep_val('m', 'p', 'somevalue', raise_for_error=False)
+
+    @mock.patch('cloud_snitch.models.utils.registry')
+    def test_invalid_property(self, m_registry):
+        """Test that PropertyNotFoundError is raised."""
+        m_model = mock.Mock()
+        m_model.properties = {
+            'test_prop': VersionedProperty(is_static=True, type=int)
+        }
+
+        m_registry.models = mock.MagicMock()
+        m_registry.models.get = mock.Mock(return_value=m_model)
+
+        # Test with raise for error
+        with self.assertRaises(PropertyNotFoundError):
+            prep_val('m', 'p', 42, raise_for_error=True)
+
+        # Test without raise for error(should still raise for this error.)
+        with self.assertRaises(PropertyNotFoundError):
+            prep_val('m', 'p', 42, raise_for_error=False)
+
+    @mock.patch('cloud_snitch.models.utils.registry')
+    def test_conversion_error(self, m_registry):
+        """Test that PropertyNotFoundError is raised."""
+        m_model = mock.Mock()
+        m_model.properties = {
+            'test_prop': VersionedProperty(is_static=True, type=int)
+        }
+        m_registry.models = mock.MagicMock()
+        m_registry.models.get = mock.Mock(return_value=m_model)
+
+        # Try converting incompatible string to int with raise_for_error
+        with self.assertRaises(ConversionError):
+            prep_val('m', 'test_prop', '42x', raise_for_error=True)
+
+        # Try converting incompatible string to int without raise_for_error
+        new_val = prep_val('m', 'test_prop', '42x', raise_for_error=False)
+        self.assertEqual(new_val, '42x')
+
+    @mock.patch('cloud_snitch.models.utils.registry')
+    def test_string_to_types(self, m_registry):
+        m_model = mock.Mock()
+        m_model.properties = {
+            'test_int': VersionedProperty(is_static=True, type=int),
+            'test_float': VersionedProperty(is_static=True, type=float),
+            'test_str': VersionedProperty(is_static=True, type=str)
+        }
+        m_registry.models = mock.MagicMock()
+        m_registry.models.get = mock.Mock(return_value=m_model)
+
+        # Test valid int
+        new_val = prep_val('m', 'test_int', '42')
+        self.assertEqual(new_val, 42)
+        self.assertTrue(isinstance(new_val, int))
+
+        # Test valid float
+        new_val = prep_val('m', 'test_float', '0.42')
+        self.assertEqual(new_val, 0.42)
+        self.assertTrue(isinstance(new_val, float))
+
+        # Test valid string
+        new_val = prep_val('m', 'test_str', 'somestr')
+        self.assertEqual(new_val, 'somestr')
+        self.assertTrue(isinstance(new_val, str))
+
+    @mock.patch('cloud_snitch.models.utils.registry')
+    def test_string_to_bool(self, m_registry):
+        m_model = mock.Mock()
+        m_model.properties = {
+            'test_bool': VersionedProperty(is_static=True, type=bool)
+        }
+        m_registry.models = mock.MagicMock()
+        m_registry.models.get = mock.Mock(return_value=m_model)
+
+        # Test false
+        self.assertFalse(prep_val('m', 'test_bool', 'false'))
+        self.assertFalse(prep_val('m', 'test_bool', 'FALSE'))
+        self.assertFalse(prep_val('m', 'test_bool', 'no'))
+        self.assertFalse(prep_val('m', 'test_bool', 'NO'))
+
+        # Test true
+        self.assertTrue(prep_val('m', 'test_bool', 'true'))
+        self.assertTrue(prep_val('m', 'test_bool', 'TRUE'))
+        self.assertTrue(prep_val('m', 'test_bool', 'yes'))
+        self.assertTrue(prep_val('m', 'test_bool', 'YES'))

--- a/cloud_snitch/tests/models/test_versioned_properties.py
+++ b/cloud_snitch/tests/models/test_versioned_properties.py
@@ -1,0 +1,85 @@
+import unittest
+
+from cloud_snitch.exc import EntityDefinitionError
+from cloud_snitch.models.base import versioned_properties
+from cloud_snitch.models.base import VersionedEntity
+from cloud_snitch.models.base import VersionedProperty
+
+
+class TestEntityDecorator(unittest.TestCase):
+    """Test the entity decorator."""
+
+    def test_valid(self):
+        """Test decorating a valid entity."""
+        @versioned_properties
+        class Entity(VersionedEntity):
+            properties = {
+                'test_id': VersionedProperty(is_identity=True),
+                'test_static': VersionedProperty(is_static=True),
+                'test_state': VersionedProperty(is_state=True),
+                'test_concat': VersionedProperty(
+                    is_static=True,
+                    concat_properties=['test_state', 'test_static']
+                )
+            }
+
+        self.assertEqual(Entity.identity_property, 'test_id')
+        self.assertTrue('test_static' in Entity.static_properties)
+        self.assertTrue('test_concat' in Entity.static_properties)
+        self.assertTrue('test_state' in Entity.state_properties)
+        self.assertEqual(
+            Entity.concat_properties['test_concat'][0],
+            'test_state'
+        )
+        self.assertEqual(
+            Entity.concat_properties['test_concat'][1],
+            'test_static'
+        )
+
+    def test_multiple_identity_properties(self):
+        """Test exception from multiple identity properties."""
+        with self.assertRaises(EntityDefinitionError):
+            @versioned_properties
+            class Entity(VersionedEntity):
+                properties = {
+                    'identity_1': VersionedProperty(is_identity=True),
+                    'identity_2': VersionedProperty(is_identity=True)
+                }
+
+    def test_no_identity_property(self):
+        """Test exception from no identity property."""
+        with self.assertRaises(EntityDefinitionError):
+            @versioned_properties
+            class Entity(VersionedEntity):
+                properties = {
+                    'test_static': VersionedProperty(is_static=True),
+                    'test_state': VersionedProperty(is_state=True)
+                }
+
+    def test_invalid_property(self):
+        """Test exception from invalid property."""
+        with self.assertRaises(EntityDefinitionError):
+            @versioned_properties
+            class Entity(VersionedEntity):
+                properties = {
+                    'test_static': VersionedProperty(
+                        is_static=True,
+                        is_state=True
+                    )
+                }
+
+    def test_multple_static_and_state_properties(self):
+        """Test entity with multiple static and state properties."""
+        @versioned_properties
+        class Entity(VersionedEntity):
+            properties = {
+                'test_identity': VersionedProperty(is_identity=True),
+                'test_static_1': VersionedProperty(is_static=True),
+                'test_state_1': VersionedProperty(is_state=True),
+                'test_static_2': VersionedProperty(is_static=True),
+                'test_state_2': VersionedProperty(is_state=True)
+            }
+        self.assertTrue('test_static_1' in Entity.static_properties)
+        self.assertTrue('test_static_2' in Entity.static_properties)
+        self.assertTrue('test_state_1' in Entity.state_properties)
+        self.assertTrue('test_state_2' in Entity.state_properties)

--- a/cloud_snitch/tests/models/test_versioned_property.py
+++ b/cloud_snitch/tests/models/test_versioned_property.py
@@ -1,0 +1,79 @@
+import unittest
+
+from cloud_snitch.models.base import VersionedProperty
+
+
+class TestVersionedProperty(unittest.TestCase):
+
+    def test_default(self):
+        """Test default values with no kwargs."""
+        prop = VersionedProperty()
+        self.assertTrue(prop.type is str)
+        self.assertTrue(prop.concat_properties is None)
+        self.assertFalse(prop.is_concat)
+        self.assertFalse(prop.is_static)
+        self.assertFalse(prop.is_state)
+        self.assertFalse(prop.is_identity)
+
+    def test_static_state_and_identity(self):
+        """Test that property is invalid when set to all."""
+        prop = VersionedProperty(
+            is_static=True,
+            is_state=True,
+            is_identity=True
+        )
+        self.assertFalse(prop.is_valid())
+
+    def test_static(self):
+        """Test a static property."""
+        prop = VersionedProperty(is_static=True)
+        self.assertTrue(prop.is_static)
+        self.assertTrue(prop.is_valid())
+
+        # Test that a static and a state property is invalid
+        prop = VersionedProperty(is_static=True, is_state=True)
+        self.assertTrue(prop.is_static)
+        self.assertTrue(prop.is_state)
+        self.assertFalse(prop.is_valid())
+
+        # Test that a static and a state property is invalid
+        prop = VersionedProperty(is_static=True, is_identity=True)
+        self.assertTrue(prop.is_static)
+        self.assertTrue(prop.is_identity)
+        self.assertFalse(prop.is_valid())
+
+    def test_state(self):
+        """Test a state property."""
+        prop = VersionedProperty(is_state=True)
+        self.assertTrue(prop.is_state)
+        self.assertTrue(prop.is_valid())
+
+        # Test that a state and a static property is invalid
+        prop = VersionedProperty(is_state=True, is_static=True)
+        self.assertTrue(prop.is_state)
+        self.assertTrue(prop.is_static)
+        self.assertFalse(prop.is_valid())
+
+        # Test that a state and a static property is invalid
+        prop = VersionedProperty(is_state=True, is_identity=True)
+        self.assertTrue(prop.is_state)
+        self.assertTrue(prop.is_identity)
+        self.assertFalse(prop.is_valid())
+
+    def test_identity(self):
+        """Test an identity property."""
+        prop = VersionedProperty(is_identity=True)
+        self.assertTrue(prop.is_identity)
+        self.assertTrue(prop.is_valid())
+
+        # Test that an identity and a static property is invalid
+        prop = VersionedProperty(is_identity=True, is_static=True)
+        self.assertTrue(prop.is_identity)
+        self.assertTrue(prop.is_static)
+        self.assertFalse(prop.is_valid())
+
+        # Test that an identity and a state property is invalid
+        prop = VersionedProperty(is_identity=True, is_state=True)
+        self.assertTrue(prop.is_identity)
+        self.assertTrue(prop.is_state)
+        self.assertFalse(prop.is_valid())

--- a/cloud_snitch/tests/models/test_virtualenv.py
+++ b/cloud_snitch/tests/models/test_virtualenv.py
@@ -1,0 +1,49 @@
+from .base import DefinitionTestCase
+
+from cloud_snitch.models import PythonPackageEntity
+from cloud_snitch.models import VirtualenvEntity
+
+
+class TestPythonPackageDefinition(DefinitionTestCase):
+    """Test python package definition."""
+    entity = PythonPackageEntity
+    label = 'PythonPackage'
+    state_label = 'PythonPackageState'
+    identity_property = 'name_version'
+    static_properties = ['name', 'version']
+    concat_properties = {
+        'name_version': [
+            'name',
+            'version'
+        ]
+    }
+
+    def test_definition(self):
+        """Test the definition."""
+        self.definition_test()
+
+
+class TestVirtualenvDefinition(DefinitionTestCase):
+    """Test virtualenv definition."""
+    entity = VirtualenvEntity
+    label = 'Virtualenv'
+    state_label = 'VirtualenvState'
+    identity_property = 'path_host'
+    static_properties = [
+        'path',
+        'host'
+    ]
+    concat_properties = {
+        'path_host': [
+            'path',
+            'host'
+        ]
+    }
+
+    children = (
+        ('pythonpackages', ('HAS_PYTHON_PACKAGE', PythonPackageEntity)),
+    )
+
+    def test_definition(self):
+        """Test the definition."""
+        self.definition_test()

--- a/web/api/serializers.py
+++ b/web/api/serializers.py
@@ -28,7 +28,41 @@ _operators = [
 
 
 class ModelSerializer(BaseSerializer):
-    """Debug serializer for dicts"""
+    """Serializer for Models."""
+    def to_representation(self, model):
+        """Get dict repr
+
+        :param model: VersionedEntity to represent
+        :type model: class
+        :returns: Dict representation
+        :rtype: dict
+        """
+        # Assemble list of properties.
+        properties = {}
+        for prop in registry.properties(model.label):
+            properties[prop] = {
+                'type': model.properties.get(prop).type.__name__
+            }
+
+        # Assemble child relationships
+        children = {}
+        for name, childtuple in model.children.items():
+            children[name] = {
+                'rel_name': childtuple[0],
+                'label': childtuple[1].label
+            }
+
+        return {
+            'label': model.label,
+            'state_label': model.state_label,
+            'properties': properties,
+            'identity': model.identity_property,
+            'children': children
+        }
+
+
+class GenericSerializer(BaseSerializer):
+    """Generic serializer for dicts"""
     def to_representation(self, obj):
         """Get dict repr
 

--- a/web/neo4jdriver/query.py
+++ b/web/neo4jdriver/query.py
@@ -1,7 +1,9 @@
 import logging
 
 from cloud_snitch.models import registry
+from cloud_snitch.models.utils import prep_val
 from cloud_snitch import utils
+
 from collections import OrderedDict
 
 from .exceptions import InvalidLabelError
@@ -136,6 +138,9 @@ class Query:
         if prop not in registry.properties(label):
             raise InvalidPropertyError(prop, label)
 
+        # Attempt a conversion for more accurate results.
+        prepped = prep_val(label, prop, value, raise_for_error=False)
+
         if prop in registry.state_properties(label):
             label = '{}_state'.format(label)
 
@@ -147,7 +152,7 @@ class Query:
         )
         self.filter_wheres.append(condition)
 
-        self.params['filterval{}'.format(self.filter_count)] = value
+        self.params['filterval{}'.format(self.filter_count)] = prepped
         self.filter_count += 1
         return self
 

--- a/web/neo4jdriver/tests/test_query.py
+++ b/web/neo4jdriver/tests/test_query.py
@@ -209,6 +209,18 @@ class TestQuery(TestCase):
         self.assertEquals(q.params['filterval0'], 'somehostname')
 
     @tag('unit')
+    @mock.patch('neo4jdriver.query.prep_val')
+    def test_filter_calls_prep_val(self, m_prep):
+        q = Query('Host')
+        q.filter('processor_cores', '=', '42')
+        m_prep.assert_called_once_with(
+            'Host',
+            'processor_cores',
+            '42',
+            raise_for_error=False
+        )
+
+    @tag('unit')
     def test_filter_with_label(self):
         """Test filtering with a non default label."""
         q = Query('Host')

--- a/web/web/static/web/html/searchpane.html
+++ b/web/web/static/web/html/searchpane.html
@@ -86,13 +86,23 @@
         <div class="hxSpan-2 hxBox-xs">
           <div>
             <select class="hxTextCtrl" name="operator" ng-model="filter.operator" ng-required="true">
-              <option ng-repeat="operator in operators" value="{{operator}}">{{operator}}</option>
+              <option ng-repeat="operator in typesService.operators(filter.model, filter.property)" value="{{operator}}">{{operator}}</option>
             </select>
           </div>
         </div>
         <div class="hxSpan-3 hxBox-xs">
-          <div>
-            <input class="hxTextCtrl" name="filterValue" ng-model="filter.value" ng-required="true" ng-maxlength="256" />
+          <div ng-switch="typesService.propertyType(filter.model, filter.property)">
+            <!-- Boolean filter value -->
+            <select ng-switch-when="bool" class="hxTextCtrl" name="filterValue" ng-model="filter.value" ng-required="true">
+              <option value="true">Yes</option>
+              <option value="false">No</option>
+            </select>
+
+            <!-- Numeric filter value -->
+            <input ng-switch-when="int|float" ng-switch-when-separator="|" type="number" class="hxTextCtrl" name="filterValue" ng-model="filter.value" ng-required="true" ng-maxlength="16" />
+
+            <!-- all others -->
+            <input ng-switch-default class="hxTextCtrl" name="filterValue" ng-model="filter.value" ng-required="true" ng-maxlength="256" />
           </div>
           <div ng-if="f.filterValue.$invalid">
             <div ng-if="f.filterValue.$error.required">


### PR DESCRIPTION
Added entity_decorator to convert dict of VersionedProperties
Added tests for checking existing model definitions
Changed model definitions to use the new VersionedProperty style.
Added util function to prep values for comparison/insertion based
    on type hint.
Changed ModelSerializer to GenericSerializer.
Added a new ModelSerializer to expose property type information.
Added ability to change available operators based on type in web
  ui filters.
Added ability to force number input on number property filters.