### PR TITLE
Enabled support for existing ssl certificated.

### DIFF
--- a/installation/local/roles/web_install/defaults/main.yml
+++ b/installation/local/roles/web_install/defaults/main.yml
@@ -88,8 +88,11 @@ cloud_snitch_web_pip_pkgs:
 
 cloud_snitch_web_alt_name: "{{ ansible_default_ipv4.address }}"
 cloud_snitch_web_self_signed_subject: "/C=US/ST=Texas/L=San Antonio/O=IT/CN={{ cloud_snitch_web_server_name }}/subjectAltName=IP.1={{ cloud_snitch_web_alt_name }}"
-cloud_snitch_web_ssl_key: /etc/ssl/private/cloudsnitchweb.key
-cloud_snitch_web_ssl_cert: /etc/ssl/certs/cloudsnitchweb.pem
+cloud_snitch_web_ssl_key_file: /etc/ssl/private/cloudsnitchweb.key
+cloud_snitch_web_ssl_cert_file: /etc/ssl/certs/cloudsnitchweb.pem
+# Set the following variables with values to use an existing cert instread of generating one.
+#cloud_snitch_web_ssl_key:
+#cloud_snitch_web_ssl_cert:
 
 cloud_snitch_web_celery_user: "{{ cloud_snitch_web_user }}"
 cloud_snitch_web_celery_group: "{{ cloud_snitch_web_group }}"

--- a/installation/local/roles/web_install/tasks/apache2.yml
+++ b/installation/local/roles/web_install/tasks/apache2.yml
@@ -14,17 +14,40 @@
 - name: Apache - Self Signed Cert
   notify:
     - Restart Apache2
+  when: cloud_snitch_web_ssl_cert is not defined and cloud_snitch_web_ssl_key is not defined
   tags:
     - apache
     - config
   args:
-    creates: "{{ cloud_snitch_web_ssl_cert }}"
+    creates: "{{ cloud_snitch_web_ssl_cert_file }}"
   command: >
     openssl req -new -nodes -sha256 -x509
     -subj "{{ cloud_snitch_web_self_signed_subject }}"
     -days 3650
-    -keyout "{{ cloud_snitch_web_ssl_key }}"
-    -out "{{ cloud_snitch_web_ssl_cert }}"
+    -keyout "{{ cloud_snitch_web_ssl_key_file }}"
+    -out "{{ cloud_snitch_web_ssl_cert_file }}"
+
+- name: Apache - SSL Key
+  notify:
+    - Restart Apache2
+  when: cloud_snitch_web_ssl_key is defined
+  template:
+    src: ssl_key.j2
+    dest: "{{ cloud_snitch_web_ssl_key_file }}"
+  tags:
+    - config
+    - apache
+
+- name: Apache - SSL Cert
+  notify:
+    - Restart Apache2
+  when: cloud_snitch_web_ssl_cert is defined
+  template:
+    src: ssl_cert.j2
+    dest: "{{ cloud_snitch_web_ssl_cert_file }}"
+  tags:
+    - config
+    - apache
 
 - name: Apache - modules
   apache2_module:
@@ -49,7 +72,7 @@
   tags:
     - config
     - apache
-   
+
 - name: Apache - Cloud Snitch Web conf
   template:
     src: 090-cloudsnitch.conf.j2

--- a/installation/local/roles/web_install/templates/090-cloudsnitch.conf.j2
+++ b/installation/local/roles/web_install/templates/090-cloudsnitch.conf.j2
@@ -11,8 +11,8 @@
 	# DocumentRoot /var/www/html
 
 	SSLEngine on
-	SSLCertificateFile {{ cloud_snitch_web_ssl_cert }}
-	SSLCertificateKeyFile {{ cloud_snitch_web_ssl_key }}
+	SSLCertificateFile {{ cloud_snitch_web_ssl_cert_file }}
+	SSLCertificateKeyFile {{ cloud_snitch_web_ssl_key_file }}
 
 	Alias /static/ {{ cloud_snitch_web_static_root }}/
 

--- a/installation/local/roles/web_install/templates/ssl_cert.j2
+++ b/installation/local/roles/web_install/templates/ssl_cert.j2
@@ -1,0 +1,1 @@
+{{ cloud_snitch_web_ssl_cert }}

--- a/installation/local/roles/web_install/templates/ssl_key.j2
+++ b/installation/local/roles/web_install/templates/ssl_key.j2
@@ -1,0 +1,1 @@
+{{ cloud_snitch_web_ssl_key }}


### PR DESCRIPTION
Changed existing variables:
  cloud_snitch_web_ssl_key -> cloud_snitch_web_ssl_key_file
  cloud_snitch_web_ssl_cert -> cloud_snitch_web_ssl_cert_file
The values of which now indicate locations.

Values for cloud_snitch_web_ssl_key and cloud_snitch_web_ssl_cert
should only be set if using an existing ssl cert.