### PR TITLE
Added permission class to determine if user is rpc racker.

### DIFF
--- a/web/common/static/common/css/alert.css
+++ b/web/common/static/common/css/alert.css
@@ -46,7 +46,7 @@ hx-alert:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-hx-alert[target="master_alert"] {
+hx-alert#master_alert {
   position: absolute;
   right: 1rem;
   top: 2rem;

--- a/web/raxauth/permissions.py
+++ b/web/raxauth/permissions.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from rest_framework.permissions import IsAuthenticated
+
+
+class IsRpcRacker(IsAuthenticated):
+    """Permission class for rpc rackers.
+
+    User must be authenticated and must have at least one
+    of a configured set of groups.
+    """
+    # Get set of rpc_groups from config.
+    rpc_groups = set(getattr(settings, 'RAXAUTH_RPC_GROUPS', []))
+
+    def has_permission(self, request, view):
+        """Check that user is authenticated and has at least one group.
+
+        :returns: Whether or not the user is authenticated and has a group
+        :rtype: bool
+        """
+        authenticated = super(IsRpcRacker, self).has_permission(request, view)
+        user_groups = getattr(request.user, 'roles', set())
+        if not isinstance(user_groups, set):
+            user_groups = set(user_groups)
+        return authenticated and bool(self.rpc_groups & user_groups)

--- a/web/raxauth/tests/test_permissions.py
+++ b/web/raxauth/tests/test_permissions.py
@@ -1,0 +1,53 @@
+import mock
+
+from django.test import TestCase
+from django.test import tag
+from raxauth.permissions import IsRpcRacker
+
+
+TEST_GROUPS = set(['group_1', 'group_2', 'group_3'])
+
+
+class FakeUser:
+    def __init__(self, is_authenticated, roles=None):
+        self.is_authenticated = is_authenticated
+        if roles is None:
+            roles = set()
+        self.roles = roles
+
+
+class FakeRequest:
+    def __init__(self, user):
+        self.user = user
+
+
+class TestIsRpcRacker(TestCase):
+    """Test IsRpcRacker permission class."""
+    @tag('unit')
+    def test_not_authenticated(self):
+        """Test a user that has not authenticated."""
+        req = FakeRequest(FakeUser(False))
+        self.assertFalse(IsRpcRacker().has_permission(req, None))
+
+    @tag('unit')
+    @mock.patch('raxauth.permissions.IsRpcRacker.rpc_groups', new=TEST_GROUPS)
+    def test_authenticated_but_not_rpc(self):
+        """Test a user that authenticates but is missing a group."""
+        req = FakeRequest(FakeUser(True))
+        self.assertFalse(IsRpcRacker().has_permission(req, None))
+
+    @tag('unit')
+    @mock.patch('raxauth.permissions.IsRpcRacker.rpc_groups', new=TEST_GROUPS)
+    def test_authenticated_and_rpc(self):
+        """Test a user that authenticates and has the group."""
+        # Test one of the three
+        req = FakeRequest(FakeUser(True, roles=['group_5', 'group_1']))
+        self.assertTrue(IsRpcRacker().has_permission(req, None))
+
+        # Test another of the three
+        req = FakeRequest(FakeUser(True, roles=['group_10', 'group_3']))
+        self.assertTrue(IsRpcRacker().has_permission(req, None))
+
+        # Test multiple of the three
+        req = FakeRequest(FakeUser(True, roles=['group_1', 'group_2']))
+        self.assertTrue(IsRpcRacker().has_permission(req, None))

--- a/web/web/templates/web/index.html
+++ b/web/web/templates/web/index.html
@@ -25,7 +25,7 @@
     <panes
       ng-if="ready && subApp == 'browse'"
       max-panes="2"></panes>
-    <hx-alert class="hxSpan-4" type="error" target="master_alert"></hx-alert>
+    <hx-alert class="hxSpan-4" id="master_alert" target="'master_alert'"></hx-alert>
   </main>
 </div>
 {% endblock %}


### PR DESCRIPTION
Permission class pulls a list of acceptable ldap groups from config
and compares to the list of groups on a raxauth user.

An additional pr will be provided to template default permission
policies for production environments.

Also fixed display bug on master alert content.