### PR TITLE
Add ansible-hardening play

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
   agent { label 'master' }
 
   environment {
+    RUN_INFRA = true
     RUN_TEST = true
     RUN_REMOTE = false
   }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,11 @@ Vagrant.configure("2") do |config|
 
 
   config.vm.provision "shell", inline: <<-SHELL
+     set -x
+
+     echo "Setting random password for root"
+     echo "root:$(openssl rand -base64 32)" | chpasswd
+
      echo "Install Packages"
      sudo apt-get update
      sudo apt-get install -y python-pip python3.5 python3.5-dev:
@@ -30,6 +35,16 @@ Vagrant.configure("2") do |config|
      virtualenv --python=python3.5 /opt/venvs/cloudsnitch
      source /opt/venvs/cloudsnitch/bin/activate
      pip install ansible
+
+     if [ #{ENV['RUN_INFRA']} == true ]; then
+       echo "Running infrastructure setup plays"
+       cd /vagrant/installation/local
+       ansible-galaxy install -r ansible_requirements.yml
+       ansible-playbook infrastructure.yml
+       echo "Completed infrastructure setup plays"
+     else
+       echo "Skipped infrastructure setup plays"
+     fi
 
      echo "Performing local installation"
      cd /vagrant/installation/local

--- a/installation/local/README.md
+++ b/installation/local/README.md
@@ -1,0 +1,60 @@
+## Infrastructure related playbooks
+
+This section covers playbooks used to configure the instances where FDR runs.
+
+### Prerequisites
+
+1. Install ansible role dependencies
+
+```
+ansible-galaxy install -r ansible_requirements.yml
+```
+
+2. All infrastructure instances are members of the `fdr_infra` group.
+:warning: Until we work out how inventory will be managed under version control, this step needs to be performed manually. :warning:
+
+Example inventory:
+
+```
+[cloud_snitch_sync]
+ingest-01
+
+[web]
+web-01
+
+[neo4j]
+neo4j-01
+
+[jump]
+jump-01
+
+[fdr_infra:children]
+cloud_snitch_sync
+web
+neo4j
+jump
+```
+
+3. The variables in `group_vars/fdr_infra.yml` have been added to the appropriate location.
+:warning: Until we work out how inventory will be managed under version control, these variables need to be kept up to date manually. :warning:
+
+### Playbooks
+
+ - `infrastructure.yml` - includes all of the following playbooks in this section
+ - `ansible-hardening.yml` - apply the [ansible-hardening](https://github.com/openstack/ansible-hardening/) role
+
+## Application components
+
+TBD - not sure on the order or prerequisites for these
+
+## Neo4J Graph DB Tier
+
+TBD
+
+## Sync Tier
+
+TBD
+
+## Web Tier
+
+TBD

--- a/installation/local/ansible-hardening.yml
+++ b/installation/local/ansible-hardening.yml
@@ -1,0 +1,5 @@
+- name: Apply ansible-hardening to FDR infra
+  hosts: fdr_infra
+  become: yes
+  roles:
+    - ansible-hardening

--- a/installation/local/ansible_requirements.yml
+++ b/installation/local/ansible_requirements.yml
@@ -1,0 +1,3 @@
+- name: ansible-hardening
+  src: git+https://github.com/openstack/ansible-hardening
+  version: 4648d7576dd574941791549a661ad1a8f595302b

--- a/installation/local/group_vars/fdr_infra.yml
+++ b/installation/local/group_vars/fdr_infra.yml
@@ -1,0 +1,8 @@
+# Configuration for ansible-hardening role
+security_check_package_checksums: yes
+security_disallow_ip_forwarding: yes
+
+# NOTE: Uncomment the following line if you are testing on an image that only
+# has a root account (e.g. public cloud).  This should never be enabled for
+# production.
+# security_sshd_permit_root_login: prohibit-password

--- a/installation/local/infrastructure.yml
+++ b/installation/local/infrastructure.yml
@@ -1,0 +1,2 @@
+---
+- import_playbook: ansible-hardening.yml


### PR DESCRIPTION
- Add a playbook to apply the `ansible-hardening` ansible role to instances the
  `fdr_infra` group.

- Add a flag ("RUN_INFRA") to toggle execution of the playbook in the `Deploy_Env`
  Jenkins job.

- Set a random password for the root user when running in public cloud since the
  role disables logins for accounts with no password set.

- Add `README.md` describing the prerequisites and manual steps required for
  running infrastructure playbooks.