### PR TITLE
Limits encrypted communications to TLSv1.2 for neo4j and apache.

### DIFF
--- a/installation/local/roles/neo4j_install/defaults/main.yml
+++ b/installation/local/roles/neo4j_install/defaults/main.yml
@@ -21,6 +21,7 @@ neo4j_ssl_policy_name: 'cloudsnitch'
 neo4j_ssl_policy_base_directory: 'certificates/{{ neo4j_ssl_policy_name }}'
 neo4j_ssl_policy_trust_all: 'true'
 neo4j_ssl_policy_allow_key_generation: 'true'
+neo4j_ssl_policy_tls_versions: 'TLSv1.2'
 
 # values are 'NONE', 'OPTIONAL', 'REQUIRE'
 # Setting to anything other than None will break the web browser

--- a/installation/local/roles/neo4j_install/templates/neo4j.conf.j2
+++ b/installation/local/roles/neo4j_install/templates/neo4j.conf.j2
@@ -194,6 +194,7 @@ dbms.ssl.policy.{{ neo4j_ssl_policy_name }}.client_auth={{ neo4j_ssl_policy_clie
 
 # A comma-separated list of allowed TLS versions.
 # By default TLSv1, TLSv1.1 and TLSv1.2 are allowed.
+dbms.ssl.policy.{{ neo4j_ssl_policy_name }}.tls_versions={{ neo4j_ssl_policy_tls_versions }}
 
 #dbms.ssl.policy.default.tls_versions=
 

--- a/installation/local/roles/web_install/defaults/main.yml
+++ b/installation/local/roles/web_install/defaults/main.yml
@@ -88,6 +88,7 @@ cloud_snitch_web_pip_pkgs:
 
 cloud_snitch_web_alt_name: "{{ ansible_default_ipv4.address }}"
 cloud_snitch_web_self_signed_subject: "/C=US/ST=Texas/L=San Antonio/O=IT/CN={{ cloud_snitch_web_server_name }}/subjectAltName=IP.1={{ cloud_snitch_web_alt_name }}"
+cloud_snitch_web_ssl_protocol: "-all +TLSv1.2"
 cloud_snitch_web_ssl_key_file: /etc/ssl/private/cloudsnitchweb.key
 cloud_snitch_web_ssl_cert_file: /etc/ssl/certs/cloudsnitchweb.pem
 # Set the following variables with values to use an existing cert instread of generating one.

--- a/installation/local/roles/web_install/templates/090-cloudsnitch.conf.j2
+++ b/installation/local/roles/web_install/templates/090-cloudsnitch.conf.j2
@@ -1,48 +1,49 @@
 <VirtualHost *:{{ cloud_snitch_web_port }}>
-	ServerName {{ cloud_snitch_web_server_name }}
-	RewriteEngine On
-	RewriteCond %{HTTPS} !=on
-	RewriteRule ^/?(.*) https://%{HTTP_HOST}:{{ cloud_snitch_web_ssl_port }}/$1 [R,L]
+    ServerName {{ cloud_snitch_web_server_name }}
+    RewriteEngine On
+    RewriteCond %{HTTPS} !=on
+    RewriteRule ^/?(.*) https://%{HTTP_HOST}:{{ cloud_snitch_web_ssl_port }}/$1 [R,L]
 </VirtualHost>
 
 <VirtualHost *:{{ cloud_snitch_web_ssl_port }}>
-	ServerName {{ cloud_snitch_web_server_name }}
-	ServerAdmin webmaster@localhost
-	# DocumentRoot /var/www/html
+    ServerName {{ cloud_snitch_web_server_name }}
+    ServerAdmin webmaster@localhost
+    # DocumentRoot /var/www/html
 
-	SSLEngine on
-	SSLCertificateFile {{ cloud_snitch_web_ssl_cert_file }}
-	SSLCertificateKeyFile {{ cloud_snitch_web_ssl_key_file }}
+    SSLEngine on
+    SSLProtocol {{ cloud_snitch_web_ssl_protocol }}
+    SSLCertificateFile {{ cloud_snitch_web_ssl_cert_file }}
+    SSLCertificateKeyFile {{ cloud_snitch_web_ssl_key_file }}
 
-	Alias /static/ {{ cloud_snitch_web_static_root }}/
+    Alias /static/ {{ cloud_snitch_web_static_root }}/
 
-	WSGIDaemonProcess cloudsnitch python-home={{ cloud_snitch_web_venv }}  python-path={{ cloud_snitch_web_project_dir}}
-	WSGIScriptAlias / {{ cloud_snitch_web_app_dir}}/wsgi.py
-        WSGIProcessGroup cloudsnitch
+    WSGIDaemonProcess cloudsnitch python-home={{ cloud_snitch_web_venv }}  python-path={{ cloud_snitch_web_project_dir}}
+    WSGIScriptAlias / {{ cloud_snitch_web_app_dir}}/wsgi.py
+    WSGIProcessGroup cloudsnitch
 
-	<Directory {{ cloud_snitch_web_app_dir }}>
-	<Files wsgi.py>
-	Require all granted
-	</Files>
-	</Directory>
+    <Directory {{ cloud_snitch_web_app_dir }}>
+    <Files wsgi.py>
+    Require all granted
+    </Files>
+    </Directory>
 
-	<Directory {{ cloud_snitch_web_static_root }}>
-	Require all granted
-	</Directory>
+    <Directory {{ cloud_snitch_web_static_root }}>
+    Require all granted
+    </Directory>
 
-	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
-	# error, crit, alert, emerg.
-	# It is also possible to configure the loglevel for particular
-	# modules, e.g.
-	#LogLevel info ssl:warn
+    # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+    # error, crit, alert, emerg.
+    # It is also possible to configure the loglevel for particular
+    # modules, e.g.
+    #LogLevel info ssl:warn
 
-	ErrorLog {{ cloud_snitch_web_log_dir }}/error.log
-	CustomLog {{ cloud_snitch_web_log_dir }}/access.log combined
+    ErrorLog {{ cloud_snitch_web_log_dir }}/error.log
+    CustomLog {{ cloud_snitch_web_log_dir }}/access.log combined
 
-	# For most configuration files from conf-available/, which are
-	# enabled or disabled at a global level, it is possible to
-	# include a line for only one particular virtual host. For example the
-	# following line enables the CGI configuration for this host only
-	# after it has been globally disabled with "a2disconf".
-	#Include conf-available/serve-cgi-bin.conf
+    # For most configuration files from conf-available/, which are
+    # enabled or disabled at a global level, it is possible to
+    # include a line for only one particular virtual host. For example the
+    # following line enables the CGI configuration for this host only
+    # after it has been globally disabled with "a2disconf".
+    #Include conf-available/serve-cgi-bin.conf
 </VirtualHost>


### PR DESCRIPTION
Sets the neo4j cloudsnitch ssl policy tls versions to TLSv1.2.
Sets the SSLProtocol for the cloud snitch vhost to TLSv1.2.