### PR TITLE
Fix missing `git clone` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ git clone git@github.com:rcbops/rpc-uam.git /opt/rpc-uam
 
 2. Clone FDR to /opt/FleetDeploymentReporting
 ```
-git@github.com:rcbops/FleetDeploymentReporting.git /opt/FleetDeploymentReporting
+git clone git@github.com:rcbops/FleetDeploymentReporting.git /opt/FleetDeploymentReporting
 ```
 
 3. Configure ansible to use FDR's version-controlled inventory


### PR DESCRIPTION
This commit adds a missing `git clone` to the installation steps.