### PR TITLE
Add Splunk Universal Forwarder playbooks

### DIFF
--- a/installation/local/README.md
+++ b/installation/local/README.md
@@ -14,6 +14,7 @@ ansible-galaxy install -r ansible_requirements.yml
 
  - `infrastructure.yml` - includes all of the following playbooks in this section
  - `ansible-hardening.yml` - apply the [ansible-hardening](https://github.com/openstack/ansible-hardening/) role
+ - `splunk.yml` - install and configure Splunk [as specified](https://one.rackspace.com/display/gss/Splunk+PCI+Playbook) by the SAAC team
 
 ## Application components
 

--- a/installation/local/infrastructure.yml
+++ b/installation/local/infrastructure.yml
@@ -1,2 +1,3 @@
 ---
 - import_playbook: ansible-hardening.yml
+- import_playbook: splunk.yml

--- a/installation/local/roles/splunk/defaults/main.yml
+++ b/installation/local/roles/splunk/defaults/main.yml
@@ -1,0 +1,14 @@
+# This is the current version specified by the SAAC team.  I initally tried
+# 7.2.1, but it had errors on some of the config pushed down from SAAC's
+# infrastructure
+
+# SAAC maintains the a link to the "latest" package [here](https://one.rackspace.com/pages/viewpage.action?pageId=196183520#SplunkPCIPlaybook-ManualInstallInstructions)
+
+splunk_deb_url: https://download.splunk.com/products/universalforwarder/releases/7.1.2/linux/splunkforwarder-7.1.2-a0c72a66db66-linux-2.6-amd64.deb
+splunk_deb_md5: 47115146ca10dbc8f00befef04b33cd7
+
+# This is the deployment server specified by the SAAC team
+splunk_deployment_server_uri: 10.12.180.99:8089
+
+# This is the device's official PCI asset name
+splunk_eris_hostname: "{{ ansible_fqdn }}"

--- a/installation/local/roles/splunk/files/SAAC_PCI_auditd.rules
+++ b/installation/local/roles/splunk/files/SAAC_PCI_auditd.rules
@@ -1,0 +1,121 @@
+# This file contains the auditctl rules that are loaded
+# whenever the audit daemon is started via the initscripts.
+# The rules are simply the parameters that would be passed
+# to auditctl.
+
+# First rule - delete all
+-D
+
+# Increase the buffers to survive stress events.
+# Make this bigger for busy systems
+-b 320
+
+# Feel free to add below this line. See auditctl man page
+
+# PCI Requirement 10.2.1 - exclude excessive messages
+-a exclude,always -F msgtype=CWD
+
+# Section 5.2.4 -  Record Events That Modify Date and Time Information
+-a always,exit -F arch=b64 -S adjtimex -S settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex -S settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S stime -k audit_time_rules
+-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change
+-w /etc/localtime -p wa -k time-change
+-a exit,always -S all -F euid=0 -F perm=awx -k root-commands
+
+# Section 5.2.5 - Record Events That Modify User/Group Information
+-w /etc/group -p wa -k identity
+-w /etc/passwd -p wa -k identity
+-w /etc/gshadow -p wa -k identity
+-w /etc/shadow -p wa -k identity
+-w /etc/security/opasswd -p wa -k identity
+
+# Section 5.2.6 - Record Events That Modify the System's Network Environment
+-a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale
+-a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
+-w /etc/issue -p wa -k system-locale
+-w /etc/issue.net -p wa -k system-locale
+-w /etc/hosts -p wa -k system-locale
+#-w /etc/sysconfig/network -p wa -k system-locale
+
+# Section 5.2.7 - Record Events That Modify the System's Mandatory Access Controls
+-w /etc/selinux/ -p wa -k MAC-policy
+
+# Section 5.2.8 - Collect Login and Logout Events
+-w /var/log/tallylog -p wa -k logins
+-w /var/run/faillock/ -p wa -k logins
+-w /var/log/lastlog -p wa -k logins
+
+# Section 5.2.9 - Collect Session Initiation Information
+-w /var/run/utmp -p wa -k session
+-w /var/log/wtmp -p wa -k session
+-w /var/log/btmp -p wa -k session
+
+# Section 5.2.10 - Collect Discretionary Access Control Permission Modification Events
+-a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+
+# Section 5.2.11 - Collect Unsuccessful Unauthorized Access Attempts to Files
+-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+
+# Section 5.2.12 - Collect Use of Privileged Commands (Please review each of these commands to ensure they will execute properly on the server)
+#-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+#-a always,exit -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+#-a always,exit -F path=/usr/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+#-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+#-a always,exit -F path=/usr/sbin/netreport -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+#-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+#-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+#-a always,exit -F path=/usr/sbin/mount.nfs -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+#-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/write -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/wall -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/pkexec -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+
+# Section 5.2.13 - Collect Successful File System Mounts
+-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
+-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
+
+# Section 5.2.14 - Collect File Deletion Events by User
+-a always,exit -F arch=b64 -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
+
+# Section 5.2.15 - Collect Changes to System Administration Scope (sudoers)
+-w /etc/sudoers -p wa -k scope
+
+# Section 5.2.16 - Collect System Administrator Actions (sudolog)
+-w /var/log/sudo.log -p wa -k actions
+
+# Section 5.2.17 - Collect Kernel Module Loading and Unloading
+-w /usr/sbin/insmod -p x -k modules
+-w /usr/sbin/rmmod -p x -k modules
+-w /usr/sbin/modprobe -p x -k modules
+-a always,exit -F arch=b64 -S init_module -S delete_module -k modules
+
+# Section 5.2.18 - Make the Audit Configuration Immutable
+-e 2

--- a/installation/local/roles/splunk/handlers/main.yml
+++ b/installation/local/roles/splunk/handlers/main.yml
@@ -1,0 +1,15 @@
+- name: restart auditd
+  service:
+    name: auditd
+    state: restarted
+
+- name: generate auditd rules
+  command: augenrules --load
+  notify: restart auditd
+
+- name: restart splunk
+  become: yes
+  become_user: splunk
+  command: ./splunk restart
+  args:
+    chdir: /opt/splunkforwarder/bin

--- a/installation/local/roles/splunk/tasks/bootstrap.yml
+++ b/installation/local/roles/splunk/tasks/bootstrap.yml
@@ -1,0 +1,51 @@
+- name: Create zzz_deploymentclient app directories
+  file:
+    path: /opt/splunkforwarder/etc/apps/zzz_deploymentclient/local/
+    owner: splunk
+    group: splunk
+    recurse: yes
+
+# After the initial start, Splunk manages these files, so we should not update
+# them.
+- name: Write initial zzz_deploymentclient configuration
+  template:
+    src: "deploymentclient/{{ item }}"
+    dest: "/opt/splunkforwarder/etc/apps/zzz_deploymentclient/local/{{ item }}"
+    owner: splunk
+    group: splunk
+  with_items:
+    - app.conf
+    - deploymentclient.conf
+
+# After the initial start, Splunk manages these files, so we should not update
+# them.
+- name: Write initial Splunk system configuration
+  template:
+    src: "system/{{ item }}"
+    dest: "/opt/splunkforwarder/etc/system/local/{{ item }}"
+    owner: splunk
+    group: splunk
+  with_items:
+    - inputs.conf
+    - server.conf
+
+- name: Perform initial configuration
+  become: yes
+  become_user: splunk
+  command: ./splunk start --accept-license --answer-yes --no-prompt
+  args:
+    chdir: /opt/splunkforwarder/bin
+
+- name: Perform restart to fully load pushed configs
+  become: yes
+  become_user: splunk
+  command: ./splunk restart
+  args:
+    chdir: /opt/splunkforwarder/bin
+
+- name: Enable starting at boot
+  become: yes
+  command: ./splunk enable boot-start -user splunk
+  args:
+    chdir: /opt/splunkforwarder/bin
+

--- a/installation/local/roles/splunk/tasks/main.yml
+++ b/installation/local/roles/splunk/tasks/main.yml
@@ -1,0 +1,62 @@
+# This playbook attempts to follow the process documented at
+# https://one.rackspace.com/display/gss/Splunk+PCI+Playbook as closely as
+# possible.
+
+---
+- name: Copy SAAC's PCI auditd rules
+  copy:
+    src: SAAC_PCI_auditd.rules
+    dest: /etc/audit/rules.d
+  notify: generate auditd rules
+
+- name: Configure auditd to use adm group for logs
+  lineinfile:
+    path: /etc/audit/auditd.conf
+    regexp: '^log_group ='
+    line: 'log_group = adm'
+  notify: restart auditd
+
+- name: Ensure /var/log/audit*'s group is adm
+  file:
+    path: /var/log/audit
+    group: adm
+    state: directory
+    recurse: yes
+  notify: restart splunk
+
+- name: Download Splunk Universal Forwarder package
+  local_action:
+    module: get_url
+    url: "{{ splunk_deb_url }}"
+    checksum: "md5:{{ splunk_deb_md5 }}"
+    dest: /tmp
+  delegate_to: localhost
+  run_once: true
+  register: splunk_pkg
+
+- name: Copy Splunk Universal Forwarder package to target
+  copy:
+    src: "{{ splunk_pkg.dest }}"
+    dest: "{{ splunk_pkg.dest }}"
+
+- name: Install Splunk Universal Forwarder package
+  apt:
+    deb: "{{ splunk_pkg.dest }}"
+    state: present
+
+- name: Determine if Splunk has been initialized
+  stat:
+    path: /opt/splunkforwarder/var/lib/splunk
+  register: splunk_init
+
+- name: Initialize Splunk
+  import_tasks: bootstrap.yml
+  when: splunk_init.stat.exists == False
+
+- name: Add splunk user to adm group
+  user:
+    name: splunk
+    append: yes
+    groups:
+      - adm
+  notify: restart splunk

--- a/installation/local/roles/splunk/templates/deploymentclient/README.md
+++ b/installation/local/roles/splunk/templates/deploymentclient/README.md
@@ -1,0 +1,1 @@
+The files in this directory represent the contents of `zzz_deploymentclient.zip` from SAAC's [sharepoint](https://one.rackspace.com/pages/viewpage.action?pageId=196183520#SplunkPCIPlaybook-ManualInstallInstructions).

--- a/installation/local/roles/splunk/templates/deploymentclient/app.conf
+++ b/installation/local/roles/splunk/templates/deploymentclient/app.conf
@@ -1,0 +1,2 @@
+# This template is intentionally blank.  Splunk will add configuration after
+# initialization.

--- a/installation/local/roles/splunk/templates/deploymentclient/deploymentclient.conf
+++ b/installation/local/roles/splunk/templates/deploymentclient/deploymentclient.conf
@@ -1,0 +1,4 @@
+[deployment-client]
+
+[target-broker:deploymentServer]
+targetUri = {{ splunk_deployment_server_uri }}

--- a/installation/local/roles/splunk/templates/system/inputs.conf
+++ b/installation/local/roles/splunk/templates/system/inputs.conf
@@ -1,0 +1,2 @@
+[default]
+host = {{ splunk_eris_hostname }}

--- a/installation/local/roles/splunk/templates/system/server.conf
+++ b/installation/local/roles/splunk/templates/system/server.conf
@@ -1,0 +1,2 @@
+[general]
+serverName = {{ splunk_eris_hostname }}

--- a/installation/local/splunk.yml
+++ b/installation/local/splunk.yml
@@ -1,0 +1,5 @@
+- name: Apply splunk role to fdr_infra hosts
+  hosts: fdr_infra
+  become: yes
+  roles:
+    - splunk


### PR DESCRIPTION
This commit adds a playbook to install and configure the Splunk Universal
Forwarder as specified by the SAAC team.