### PR TITLE
Fixes issue causing middle nodes not to render as changed.

### DIFF
--- a/cloud_snitch/models/registry.py
+++ b/cloud_snitch/models/registry.py
@@ -107,18 +107,25 @@ class Forest:
         paths = []
 
         current_node = self.nodes.get(label)
+        if current_node is None:
+            return []
+
         stack = [current_node]
         while (stack):
             current = stack[-1]
-            visited.add(current)
+            # Add current path if not yet visited
+            if current not in visited:
+                paths.append([n.label for n in stack])
+                visited.add(current)
+
             for rel_name, child_node in current.children.items():
                 if child_node not in visited:
                     stack.append(child_node)
                     break
             else:
-                if not current.children:
-                    paths.append([n.label for n in stack])
                 stack.pop()
+
+        paths = sorted(paths, key=lambda x: len(x))
         return paths
 
 

--- a/cloud_snitch/tests/models/test_registry.py
+++ b/cloud_snitch/tests/models/test_registry.py
@@ -1,0 +1,27 @@
+import unittest
+
+from cloud_snitch.models import registry
+
+
+class TestPathsFrom(unittest.TestCase):
+    """Test outcomes of the paths_from member function of the forest."""
+    def test_bad_label(self):
+        """Test that invalid label results in empty list."""
+        model = 'notamodel'
+        paths = registry.forest.paths_from(model)
+        self.assertTrue(isinstance(paths, list))
+        self.assertEqual(len(paths), 0)
+
+    def test_model_is_in_path_to_itself(self):
+        """Test that the first path is of length 1 and is to itself."""
+        model = 'Environment'
+        first = registry.forest.paths_from(model)[0]
+        self.assertEqual(len(first), 1)
+        self.assertEqual(first[0], model)
+
+    def test_sorted(self):
+        """Test that paths are produced in order by ascending length."""
+        model = 'Environment'
+        paths = registry.forest.paths_from(model)
+        for i in range(1, len(paths)):
+            self.assertTrue(len(paths[i]) >= len(paths[i - 1]))

--- a/web/api/diff.py
+++ b/web/api/diff.py
@@ -538,9 +538,6 @@ class Diff:
 
         # Get list of paths
         paths = registry.forest.paths_from(self.model)
-        paths.append([self.model])
-        paths = sorted(paths, key=lambda x: len(x))
-
         for p in paths:
             q = DiffSideQuery(p, identity, (t1, t2))
             for row in q.fetch_all():


### PR DESCRIPTION
The path_from function of the registry was only counting leaf
paths. This change alters that function to include a path to self
and all paths to intermediate nodes on the way to a leaf node.