### PR TITLE
Fixes issue where last_sync field is rendered as ms timestamp.

### DIFF
--- a/web/common/static/common/css/cloudsnitch.css
+++ b/web/common/static/common/css/cloudsnitch.css
@@ -44,7 +44,7 @@ div.close-outer {
   font-style: italic;
 }
 
-.configContents {
+.cs-file {
   max-height: 300px;
   width: 650px;
 }

--- a/web/web/static/web/html/csfield.html
+++ b/web/web/static/web/html/csfield.html
@@ -1,0 +1,7 @@
+<ng-switch on="$ctrl.displayType">
+  <pre ng-switch-when="file" class="cs-file">
+    <code>{{ $ctrl.value }}</code>
+  </pre>
+  <span ng-switch-when="datetime" class="cs-datetime">{{ $ctrl.value | localtime }}</span>
+  <span ng-switch-default class="cs-text">{{ $ctrl.value }}</span>
+</ng-switch>

--- a/web/web/static/web/html/panes/details.html
+++ b/web/web/static/web/html/panes/details.html
@@ -27,17 +27,14 @@
         </tr>
         <tr ng-if="$ctrl.obj.created_at">
           <td>discovered on</td>
-          <td>{{ $ctrl.obj.created_at | localtime }}</td>
+          <td><cs-field label="$ctrl.type" property="'created_at'" value="$ctrl.obj.created_at"></cs-field></td>
         </tr>
         <tr>
           <td colspan="2">&nbsp;</td>
         </tr>
         <tr ng-repeat="key in $ctrl.properties">
             <td>{{ key }}</td>
-            <td>
-                <pre class="configContents" ng-if="$ctrl.type == 'Configfile' && key == 'contents'"><code>{{ $ctrl.obj[key] }}</code></pre>
-                <span ng-if="!($ctrl.type == 'Configfile' && key == 'contents')">{{ $ctrl.obj[key] }}</span>
-            </td>
+            <td><cs-field label="$ctrl.type" property="key" value="$ctrl.obj[key]"></cs-field></td>
         </tr>
       </tbody>
     </table>

--- a/web/web/static/web/html/panes/diffdetails.html
+++ b/web/web/static/web/html/panes/diffdetails.html
@@ -16,8 +16,12 @@
         <tbody>
           <tr ng-repeat="prop in $ctrl.properties">
             <td>{{ prop.name }}</td>
-            <td ng-class="{diffLeft: $ctrl.isDifferent($index)}">{{ prop.t1 }}</td>
-            <td ng-class="{diffRight: $ctrl.isDifferent($index)}">{{ prop.t2 }}</td>
+            <td ng-class="{diffLeft: $ctrl.isDifferent($index)}">
+              <cs-field label="$ctrl.type" property="prop.name" value="prop.t1"></cs-field>
+            </td>
+            <td ng-class="{diffRight: $ctrl.isDifferent($index)}">
+              <cs-field label="$ctrl.type" property="prop.name" value="prop.t2"></cs-field>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/web/web/static/web/js/components/common.js
+++ b/web/web/static/web/js/components/common.js
@@ -86,3 +86,22 @@ angular.module("cloudSnitch").component("expandableTableContent", {
         onRowClick: "&"
     }
 });
+
+function CSFieldController(typesService) {
+    var self = this;
+
+    self.$onInit = function() {
+        self.displayType = typesService.displayType(self.label, self.property) || "text";
+    };
+}
+
+angular.module("cloudSnitch").component("csField", {
+    templateUrl: "/static/web/html/csfield.html",
+    controller: ["typesService", CSFieldController],
+    bindings: {
+        label: "<",
+        property: "<",
+        value: "<"
+    }
+});
+

--- a/web/web/static/web/js/filters/localtime.js
+++ b/web/web/static/web/js/filters/localtime.js
@@ -1,5 +1,5 @@
 angular.module("cloudSnitch").filter("localtime", ["timeService", function(timeService) {
     return function(input) {
-        return timeService.str(timeService.local(timeService.fromMilliseconds(input)));
+        return timeService.str(timeService.fromMilliseconds(input));
     };
 }]);

--- a/web/web/static/web/js/services/types.js
+++ b/web/web/static/web/js/services/types.js
@@ -1,5 +1,11 @@
 angular.module("cloudSnitch").factory("typesService", ["$rootScope", "$log", "cloudSnitchApi", "messagingService", function($rootScope, $log, cloudSnitchApi, messagingService) {
 
+    const fieldTypes = {
+        datetime: "datetime",
+        file: "file",
+        text: "text"
+    };
+
     var service = {};
     service.types = [];
     service.typeMap = {};
@@ -32,7 +38,7 @@ angular.module("cloudSnitch").factory("typesService", ["$rootScope", "$log", "cl
 
     service.diffLabelView = {
         AptPackage: "name",
-        ConfigFile: "name",
+        Configfile: "name",
         ConfiguredInterface: "device",
         Device: "name",
         Environment: "name",
@@ -50,6 +56,28 @@ angular.module("cloudSnitch").factory("typesService", ["$rootScope", "$log", "cl
         PythonPackage: "name",
         Uservar: "name",
         Virtualenv: "path"
+    };
+
+    var displayTypes = {
+        AptPackage:            { created_at: fieldTypes.datetime },
+        Configfile:            { created_at: fieldTypes.datetime, contents: fieldTypes.file },
+        ConfiguredInterface:   { created_at: fieldTypes.datetime },
+        Device:                { created_at: fieldTypes.datetime },
+        Environment:           { created_at: fieldTypes.datetime, last_sync: fieldTypes.datetime },
+        GitRemote:             { created_at: fieldTypes.datetime },
+        GitRepo:               { created_at: fieldTypes.datetime },
+        GitUntrackedFile:      { created_at: fieldTypes.datetime },
+        GitUrl:                { created_at: fieldTypes.datetime },
+        Host:                  { created_at: fieldTypes.datetime },
+        Interface:             { created_at: fieldTypes.datetime },
+        KernelModule:          { created_at: fieldTypes.datetime },
+        KernelModuleParameter: { created_at: fieldTypes.datetime },
+        Mount:                 { created_at: fieldTypes.datetime },
+        NameServer:            { created_at: fieldTypes.datetime },
+        Partition:             { created_at: fieldTypes.datetime },
+        PythonPackage:         { created_at: fieldTypes.datetime },
+        Uservar:               { created_at: fieldTypes.datetime },
+        Virtualenv:            { created_at: fieldTypes.datetime }
     };
 
     var strOperators = [
@@ -205,6 +233,21 @@ angular.module("cloudSnitch").factory("typesService", ["$rootScope", "$log", "cl
             type = "str";
         }
         return type;
+    };
+
+    /**
+     * Get the display type of a label and property.
+     */
+    service.displayType = function(label, property) {
+        var t = fieldTypes.text;
+        try {
+            // DisplayTypes[label] may be defined with missing property.
+            t = displayTypes[label][property] || fieldTypes.text;
+        }
+        catch(e) {
+            // Empty
+        }
+        return t;
     };
 
     /**


### PR DESCRIPTION
Alters the type service to allow components to discover the
display type for a given model and property. Available display
types so far are: datetime, file, and text.

Added a cs-field component that accepts a model, a property, and
a value and renderes the value accordingly. Files are rendered
in <pre><code></code></pre> tags. Text is rendered as is with no
alterations. Datetime as passed through the localtime filter.